### PR TITLE
fix(serve): accept content-part arrays on OpenAI tool messages

### DIFF
--- a/src/serve/openai_schema.cpp
+++ b/src/serve/openai_schema.cpp
@@ -244,12 +244,16 @@ void parse_messages(const Json& body, GenerationRequest& out) {
                 item.at("tool_call_id").get<std::string>().empty()) {
                 bad_request("tool messages must contain a string tool_call_id", "messages");
             }
-            if (!item.contains("content") || !item.at("content").is_string()) {
-                bad_request("tool messages must contain string content", "messages");
+            if (!item.contains("content") || item.at("content").is_null()) {
+                bad_request("tool messages must contain content", "messages");
             }
             turn.tool_call_id = item.at("tool_call_id").get<std::string>();
-            turn.content.push_back(
-                ContentPart{ContentKind::Text, item.at("content").get<std::string>(), "text"});
+            const Json& tool_content = item.at("content");
+            if (tool_content.is_array() && tool_content.empty()) {
+                turn.content.push_back(ContentPart{ContentKind::Text, {}, "text"});
+            } else {
+                parse_content_parts(tool_content, turn, i);
+            }
             out.messages.push_back(std::move(turn));
             continue;
         }

--- a/tests/test_openai_schema.cpp
+++ b/tests/test_openai_schema.cpp
@@ -460,6 +460,31 @@ int test_parse_tool_history_messages() {
     failures += check(to_request_options(req, default_server()).output.preserve_special_tokens,
                       "tool history preserves special tokens in Engine output");
 
+    Json parts_body                      = body;
+    parts_body["messages"][2]["content"] = Json::array(
+        {Json{{"type", "text"}, {"text", R"({"temp":20})"}}, Json{{"type", "text"}, {"text", "ok"}}});
+    const GenerationRequest parts_req = parse_chat_completion_request(parts_body, default_limits());
+    failures += check(parts_req.messages[2].content.size() == 2, "tool content parts parsed");
+    failures += check(parts_req.messages[2].content.at(0).text == R"({"temp":20})",
+                      "tool content part 0 parsed");
+    failures += check(parts_req.messages[2].content.at(1).text == "ok", "tool content part 1 parsed");
+    failures += check(parts_req.messages[2].tool_call_id == "call_1",
+                      "tool_call_id parsed with content parts");
+
+    Json empty_parts_body                      = body;
+    empty_parts_body["messages"][2]["content"] = Json::array();
+    const GenerationRequest empty_parts_req =
+        parse_chat_completion_request(empty_parts_body, default_limits());
+    failures += check(empty_parts_req.messages[2].content.size() == 1 &&
+                          empty_parts_req.messages[2].content.at(0).text.empty(),
+                      "empty tool content parts accepted");
+
+    Json null_content_body                      = body;
+    null_content_body["messages"][2]["content"] = nullptr;
+    failures += check(
+        throws_api([&] { (void)parse_chat_completion_request(null_content_body, default_limits()); }),
+        "null tool content rejected");
+
     Json bad_args                                                     = body;
     bad_args["messages"][1]["tool_calls"][0]["function"]["arguments"] = R"(["Paris"])";
     failures +=


### PR DESCRIPTION
Tool messages were required to carry a plain JSON string content, but the Chat Completions spec also permits an array of content parts, and agent clients such as Qwen Code always send that form. Every tool result was rejected with a 400, breaking tool-calling sessions on the first call.

Route tool content through the same parse_content_parts path already used for user and assistant roles, mapping an empty array to an empty text part and still rejecting missing or null content.

Fixed via Opus 5