### PR TITLE
fix(serve): report chat prefix cache usage

### DIFF
--- a/docs/serving.md
+++ b/docs/serving.md
@@ -109,6 +109,10 @@ Streaming begins with an assistant-role chunk, sends separate reasoning and cont
 finish-reason chunk and `[DONE]`. When `stream_options.include_usage` is true, a final empty
 `choices` chunk contains completed usage.
 
+Both non-streaming responses and the final streaming usage chunk report the exact resident prompt
+prefix reused by Engine as `usage.prompt_tokens_details.cached_tokens`. `usage.prompt_tokens`
+includes those cached tokens.
+
 ### Multimodal request
 
 Start the server with `--vision` before sending media:

--- a/src/serve/generation_service.cpp
+++ b/src/serve/generation_service.cpp
@@ -16,6 +16,11 @@
 
 namespace ninfer::serve {
 
+CompletionUsage make_completion_usage(const GenerationOutcome& outcome) {
+    return CompletionUsage{outcome.prompt_tokens, outcome.completion_tokens,
+                           static_cast<int>(outcome.metrics.prefix_cache_hit_tokens)};
+}
+
 struct RequestCapacity {
     explicit RequestCapacity(std::size_t limit) : maximum(limit) {}
 

--- a/src/serve/generation_service.h
+++ b/src/serve/generation_service.h
@@ -53,6 +53,8 @@ struct GenerationOutcome {
     GenerationMetrics metrics;
 };
 
+[[nodiscard]] CompletionUsage make_completion_usage(const GenerationOutcome& outcome);
+
 struct StreamSink {
     std::function<void(const std::string& delta_text)> on_content;
     std::function<void(const std::string& delta_text)> on_reasoning;

--- a/src/serve/http_server.cpp
+++ b/src/serve/http_server.cpp
@@ -365,7 +365,7 @@ void HttpServer::handle_chat_completions(const httplib::Request& req, httplib::R
                 return req.is_connection_alive && !req.is_connection_alive();
             });
             log_request_done(log_context, outcome);
-            const CompletionUsage usage{outcome.prompt_tokens, outcome.completion_tokens};
+            const CompletionUsage usage = make_completion_usage(outcome);
             std::string response_body;
             if (!outcome.tool_calls.empty()) {
                 response_body = make_chat_completion_tool_response(
@@ -450,7 +450,7 @@ void HttpServer::handle_chat_completions(const httplib::Request& req, httplib::R
                                               include_usage));
                 }
                 if (include_usage) {
-                    const CompletionUsage usage{outcome.prompt_tokens, outcome.completion_tokens};
+                    const CompletionUsage usage = make_completion_usage(outcome);
                     write_stream_item(sink, *stream,
                                       make_chat_chunk_usage(id, model, created, usage));
                 }

--- a/src/serve/openai_schema.cpp
+++ b/src/serve/openai_schema.cpp
@@ -1,5 +1,6 @@
 #include "serve/openai_schema.h"
 
+#include <algorithm>
 #include <array>
 #include <cctype>
 #include <chrono>
@@ -88,6 +89,14 @@ std::string require_function_name(const Json& obj, const char* param) {
         bad_request("function name must match [A-Za-z0-9_-]{1,64}", param);
     }
     return name;
+}
+
+Json completion_usage_json(const CompletionUsage& usage) {
+    const int cached_tokens = std::clamp(usage.cached_tokens, 0, usage.prompt_tokens);
+    return Json{{"prompt_tokens", usage.prompt_tokens},
+                {"completion_tokens", usage.completion_tokens},
+                {"total_tokens", usage.prompt_tokens + usage.completion_tokens},
+                {"prompt_tokens_details", Json{{"cached_tokens", cached_tokens}}}};
 }
 
 bool has_tool_named(const GenerationRequest& req, const std::string& name) {
@@ -584,9 +593,7 @@ std::string make_chat_completion_response(const std::string& id, const std::stri
         {"choices",
          Json::array({Json{
              {"index", 0}, {"message", std::move(message)}, {"finish_reason", finish_reason}}})},
-        {"usage", Json{{"prompt_tokens", usage.prompt_tokens},
-                       {"completion_tokens", usage.completion_tokens},
-                       {"total_tokens", usage.prompt_tokens + usage.completion_tokens}}}};
+        {"usage", completion_usage_json(usage)}};
     return payload.dump();
 }
 
@@ -607,9 +614,7 @@ std::string make_chat_completion_tool_response(const std::string& id, const std:
         {"choices",
          Json::array({Json{
              {"index", 0}, {"message", std::move(message)}, {"finish_reason", "tool_calls"}}})},
-        {"usage", Json{{"prompt_tokens", usage.prompt_tokens},
-                       {"completion_tokens", usage.completion_tokens},
-                       {"total_tokens", usage.prompt_tokens + usage.completion_tokens}}}};
+        {"usage", completion_usage_json(usage)}};
     return payload.dump();
 }
 
@@ -671,9 +676,7 @@ std::string make_chat_chunk_usage(const std::string& id, const std::string& mode
                                   std::int64_t created, const CompletionUsage& usage) {
     Json payload       = base_chunk(id, model, created);
     payload["choices"] = Json::array();
-    payload["usage"]   = Json{{"prompt_tokens", usage.prompt_tokens},
-                              {"completion_tokens", usage.completion_tokens},
-                              {"total_tokens", usage.prompt_tokens + usage.completion_tokens}};
+    payload["usage"]   = completion_usage_json(usage);
     return sse_event(payload);
 }
 

--- a/src/serve/request.h
+++ b/src/serve/request.h
@@ -49,6 +49,7 @@ struct RequestLimits {
 struct CompletionUsage {
     int prompt_tokens     = 0;
     int completion_tokens = 0;
+    int cached_tokens     = 0;
 };
 
 enum class ContentKind {

--- a/tests/test_openai_schema.cpp
+++ b/tests/test_openai_schema.cpp
@@ -4,6 +4,7 @@
 // consumed by external OpenAI clients.
 
 #include "serve/openai_schema.h"
+#include "serve/generation_service.h"
 #include "serve/request.h"
 #include "serve/translate.h"
 
@@ -549,7 +550,7 @@ int test_parse_sampling_carried() {
 
 int test_response_serialization() {
     int failures = 0;
-    const CompletionUsage usage{10, 3};
+    const CompletionUsage usage{10, 3, 7};
     const Json j = Json::parse(
         make_chat_completion_response("id-1", "m", 111, "hello world", "", "stop", usage));
     failures += check(j.at("object") == "chat.completion", "response object");
@@ -566,6 +567,8 @@ int test_response_serialization() {
     failures += check(j.at("usage").at("prompt_tokens") == 10, "usage prompt_tokens");
     failures += check(j.at("usage").at("completion_tokens") == 3, "usage completion_tokens");
     failures += check(j.at("usage").at("total_tokens") == 13, "usage total_tokens");
+    failures += check(j.at("usage").at("prompt_tokens_details").at("cached_tokens") == 7,
+                      "usage cached prompt tokens");
 
     // Non-empty reasoning is attached as message.reasoning_content, content stays answer-only.
     const Json jr = Json::parse(make_chat_completion_response("id-2", "m", 111, "the answer",
@@ -578,9 +581,37 @@ int test_response_serialization() {
     return failures;
 }
 
+int test_completion_usage_mapping_and_bounds() {
+    int failures = 0;
+
+    GenerationOutcome outcome;
+    outcome.prompt_tokens                   = 10;
+    outcome.completion_tokens               = 3;
+    outcome.metrics.prefix_cache_hit_tokens = 7;
+    const CompletionUsage mapped            = make_completion_usage(outcome);
+    failures += check(mapped.prompt_tokens == 10, "mapped prompt tokens");
+    failures += check(mapped.completion_tokens == 3, "mapped completion tokens");
+    failures += check(mapped.cached_tokens == 7, "mapped cached prompt tokens");
+
+    const Json cache_miss =
+        Json::parse(make_chat_completion_response("id-cold", "m", 111, "", "", "stop", {10, 0}));
+    failures += check(cache_miss.at("usage").at("prompt_tokens_details").at("cached_tokens") == 0,
+                      "cache miss reports zero cached tokens");
+
+    const Json below_zero = parse_sse(make_chat_chunk_usage("id-low", "m", 111, {10, 0, -1}));
+    failures += check(below_zero.at("usage").at("prompt_tokens_details").at("cached_tokens") == 0,
+                      "negative cached tokens clamp to zero");
+
+    const Json above_prompt = parse_sse(make_chat_chunk_usage("id-high", "m", 111, {10, 0, 11}));
+    failures +=
+        check(above_prompt.at("usage").at("prompt_tokens_details").at("cached_tokens") == 10,
+              "cached tokens clamp to prompt tokens");
+    return failures;
+}
+
 int test_tool_response_serialization() {
     int failures = 0;
-    const CompletionUsage usage{12, 6};
+    const CompletionUsage usage{12, 6, 8};
     const std::vector<ToolCall> calls = {
         ToolCall{"call_abc", "get_weather", R"({"city":"Paris"})"}};
     const Json j = Json::parse(
@@ -600,6 +631,8 @@ int test_tool_response_serialization() {
     failures += check(call.at("function").at("arguments") == R"({"city":"Paris"})",
                       "tool function arguments");
     failures += check(j.at("usage").at("total_tokens") == 18, "tool usage total");
+    failures += check(j.at("usage").at("prompt_tokens_details").at("cached_tokens") == 8,
+                      "tool usage cached prompt tokens");
 
     const Json with_content = Json::parse(make_chat_completion_tool_response(
         "id-tool-2", "m", 223, "Calling weather.", "", calls, usage));
@@ -648,13 +681,15 @@ int test_chunk_serialization() {
     failures += check(!final_no_usage.contains("usage"), "no usage key when include_usage=false");
 
     // Dedicated usage chunk: empty choices, populated usage.
-    const CompletionUsage usage{2, 5};
+    const CompletionUsage usage{2, 5, 1};
     const Json usage_chunk = parse_sse(make_chat_chunk_usage("id", "m", 1, usage));
     failures += check(usage_chunk.at("choices").is_array() && usage_chunk.at("choices").empty(),
                       "usage chunk has empty choices");
     failures +=
         check(usage_chunk.at("usage").at("prompt_tokens") == 2, "usage chunk prompt_tokens");
     failures += check(usage_chunk.at("usage").at("total_tokens") == 7, "usage chunk total");
+    failures += check(usage_chunk.at("usage").at("prompt_tokens_details").at("cached_tokens") == 1,
+                      "usage chunk cached prompt tokens");
 
     failures += check(sse_done() == "data: [DONE]\n\n", "done sentinel");
     return failures;
@@ -736,6 +771,7 @@ int main() {
     failures += test_parse_stop_and_max_tokens();
     failures += test_parse_sampling_carried();
     failures += test_response_serialization();
+    failures += test_completion_usage_mapping_and_bounds();
     failures += test_tool_response_serialization();
     failures += test_chunk_serialization();
     failures += test_tool_chunk_serialization();


### PR DESCRIPTION
## Summary

- expose prefix-cache reuse as `usage.prompt_tokens_details.cached_tokens` in OpenAI Chat Completions responses
- use one tested `GenerationOutcome` to `CompletionUsage` mapping for non-streaming and streaming requests
- document that `prompt_tokens` includes cached tokens

## Why

NInfer already tracks the exact reused prompt prefix in `GenerationMetrics::prefix_cache_hit_tokens`, but `/v1/chat/completions` omitted it from usage responses. OpenAI-compatible consumers such as DeepSeek Harness therefore displayed a 0% cache-hit rate even while NInfer logs showed substantial prefix reuse.

This is an additive response field only. It does not change cache policy, prompt reuse, or token accounting.

## Verification

- `ninfer_openai_schema_test`
- `ninfer_responses_schema_test`
- `ninfer_anthropic_schema_test`
- `ninfer_serve_options_test`
- `ninfer_request_log_test`
- live Qwen3.8-27B request/stream smoke test:

| Request | Prompt tokens | Cached tokens |
| --- | ---: | ---: |
| First non-streaming request | 1658 | 0 |
| Repeated non-streaming request | 1658 | 1656 |
| Repeated streaming request with `include_usage` | 1658 | 1656 |

The tests also cover tool-call responses, a cold cache, and cached-token values below zero or above the prompt length.
