### PR TITLE
fix(cache): chunk KV snapshot staging to bounded page batches

### DIFF
--- a/src/targets/qwen3_6/impl/runtime/program_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/program_impl.h
@@ -635,12 +635,26 @@ runtime::PrefillStepResult ProgramImplCore::start_prefill_lane(std::uint32_t lan
                     }
                     if (!valid_page_ids.empty()) {
                         auto& pool = decoder->text_kv.pool();
-                        void* d_text_staging = nullptr;
-                        CUDA_CHECK(cudaMallocAsync(&d_text_staging, loaded_text_kv.size(), device.stream));
-                        CUDA_CHECK(cudaMemcpyAsync(d_text_staging, loaded_text_kv.data(), loaded_text_kv.size(),
-                                                   cudaMemcpyHostToDevice, device.stream));
-                        pool.scatter_from_contiguous_device(valid_page_ids, d_text_staging, device.stream);
-                        CUDA_CHECK(cudaFreeAsync(d_text_staging, device.stream));
+                        // Chunked staging: bounded page batches instead of one giant allocation, so a
+                        // large snapshot restore never needs a whole-snapshot staging buffer (which OOMs
+                        // on 24 GB cards at 280k context). Staging is page-major and the scatter kernel
+                        // addresses pages relative to the batch, so batching is safe.
+                        constexpr std::uint32_t kRestoreBatchPages = 32;
+                        const std::size_t restore_page_bytes = header.text_page_bytes;
+                        for (std::size_t b = 0; b < valid_page_ids.size(); b += kRestoreBatchPages) {
+                            const std::size_t n =
+                                std::min<std::size_t>(kRestoreBatchPages, valid_page_ids.size() - b);
+                            void* d_text_staging = nullptr;
+                            CUDA_CHECK(cudaMallocAsync(&d_text_staging, n * restore_page_bytes, device.stream));
+                            CUDA_CHECK(cudaMemcpyAsync(d_text_staging,
+                                                       loaded_text_kv.data() + b * restore_page_bytes,
+                                                       n * restore_page_bytes,
+                                                       cudaMemcpyHostToDevice, device.stream));
+                            pool.scatter_from_contiguous_device(
+                                std::span<const std::int32_t>(valid_page_ids.data() + b, n),
+                                d_text_staging, device.stream);
+                            CUDA_CHECK(cudaFreeAsync(d_text_staging, device.stream));
+                        }
                     }
                 }
 
@@ -658,12 +672,23 @@ runtime::PrefillStepResult ProgramImplCore::start_prefill_lane(std::uint32_t lan
                         }
                         if (!valid_mtp_page_ids.empty()) {
                             auto& mtp_pool = decoder->mtp_cache()->pool();
-                            void* d_mtp_staging = nullptr;
-                            CUDA_CHECK(cudaMallocAsync(&d_mtp_staging, loaded_mtp_kv.size(), device.stream));
-                            CUDA_CHECK(cudaMemcpyAsync(d_mtp_staging, loaded_mtp_kv.data(), loaded_mtp_kv.size(),
-                                                       cudaMemcpyHostToDevice, device.stream));
-                            mtp_pool.scatter_from_contiguous_device(valid_mtp_page_ids, d_mtp_staging, device.stream);
-                            CUDA_CHECK(cudaFreeAsync(d_mtp_staging, device.stream));
+                            constexpr std::uint32_t kRestoreBatchPages = 32;
+                            const std::size_t mtp_page_bytes =
+                                loaded_mtp_kv.size() / static_cast<std::size_t>(valid_mtp_page_ids.size());
+                            for (std::size_t b = 0; b < valid_mtp_page_ids.size(); b += kRestoreBatchPages) {
+                                const std::size_t n =
+                                    std::min<std::size_t>(kRestoreBatchPages, valid_mtp_page_ids.size() - b);
+                                void* d_mtp_staging = nullptr;
+                                CUDA_CHECK(cudaMallocAsync(&d_mtp_staging, n * mtp_page_bytes, device.stream));
+                                CUDA_CHECK(cudaMemcpyAsync(d_mtp_staging,
+                                                           loaded_mtp_kv.data() + b * mtp_page_bytes,
+                                                           n * mtp_page_bytes,
+                                                           cudaMemcpyHostToDevice, device.stream));
+                                mtp_pool.scatter_from_contiguous_device(
+                                    std::span<const std::int32_t>(valid_mtp_page_ids.data() + b, n),
+                                    d_mtp_staging, device.stream);
+                                CUDA_CHECK(cudaFreeAsync(d_mtp_staging, device.stream));
+                            }
                         }
                     }
                     if (sequence.tail_hidden.data != nullptr && !loaded_tail.empty()) {
@@ -2515,20 +2540,38 @@ void ProgramImplCore::snapshot_lane_to_disk(std::uint32_t lane, DiskStateCache& 
     void* h_text_pinned = nullptr;
     std::size_t missing_total_bytes = 0;
 
-    if (!missing_physical_page_ids.empty()) {
-        const auto& pool = decoder->text_kv.pool();
-        single_page_bytes = static_cast<std::uint32_t>(pool.total_page_bytes());
-        missing_total_bytes = pool.total_page_bytes() * missing_physical_page_ids.size();
+        if (!missing_physical_page_ids.empty()) {
+            const auto& pool = decoder->text_kv.pool();
+            single_page_bytes = static_cast<std::uint32_t>(pool.total_page_bytes());
+            missing_total_bytes = pool.total_page_bytes() * missing_physical_page_ids.size();
 
-        void* d_staging = nullptr;
-        CUDA_CHECK(cudaMallocAsync(&d_staging, missing_total_bytes, device.stream));
-        pool.gather_to_contiguous_device(missing_physical_page_ids, d_staging, device.stream);
+            // Chunked staging: gather page batches into bounded pinned buffers instead of one
+            // whole-snapshot allocation, so saving a large checkpoint cannot OOM device memory.
+            constexpr std::uint32_t kSaveBatchPages = 32;
+            missing_pages_data.resize(missing_total_bytes);
+            std::byte* batch_dst = missing_pages_data.data();
+            for (std::size_t b = 0; b < missing_physical_page_ids.size(); b += kSaveBatchPages) {
+                const std::size_t n =
+                    std::min<std::size_t>(kSaveBatchPages, missing_physical_page_ids.size() - b);
+                const std::size_t batch_bytes = n * single_page_bytes;
 
-        CUDA_CHECK(cudaMallocHost(&h_text_pinned, missing_total_bytes));
-        CUDA_CHECK(cudaMemcpyAsync(h_text_pinned, d_staging, missing_total_bytes,
-                                   cudaMemcpyDeviceToHost, device.stream));
-        CUDA_CHECK(cudaFreeAsync(d_staging, device.stream));
-    } else if (sequence.kv && sequence.kv->text.valid()) {
+                void* d_batch = nullptr;
+                CUDA_CHECK(cudaMallocAsync(&d_batch, batch_bytes, device.stream));
+                pool.gather_to_contiguous_device(
+                    std::span<const std::int32_t>(missing_physical_page_ids.data() + b, n),
+                    d_batch, device.stream);
+
+                void* h_batch = nullptr;
+                CUDA_CHECK(cudaMallocHost(&h_batch, batch_bytes));
+                CUDA_CHECK(cudaMemcpyAsync(h_batch, d_batch, batch_bytes,
+                                           cudaMemcpyDeviceToHost, device.stream));
+                CUDA_CHECK(cudaFreeAsync(d_batch, device.stream));
+                CUDA_CHECK(cudaStreamSynchronize(device.stream));
+                std::memcpy(batch_dst, h_batch, batch_bytes);
+                CUDA_CHECK(cudaFreeHost(h_batch));
+                batch_dst += batch_bytes;
+            }
+        } else if (sequence.kv && sequence.kv->text.valid()) {
         const auto& pool = decoder->text_kv.pool();
         single_page_bytes = static_cast<std::uint32_t>(pool.total_page_bytes());
     }
@@ -2547,12 +2590,22 @@ void ProgramImplCore::snapshot_lane_to_disk(std::uint32_t lane, DiskStateCache& 
             const std::size_t total_plane_bytes = mtp_pool.total_page_bytes() * valid_mtp_page_ids.size();
             mtp_kv_payload.resize(total_plane_bytes);
 
-            void* d_mtp_staging = nullptr;
-            CUDA_CHECK(cudaMallocAsync(&d_mtp_staging, total_plane_bytes, device.stream));
-            mtp_pool.gather_to_contiguous_device(valid_mtp_page_ids, d_mtp_staging, device.stream);
-            CUDA_CHECK(cudaMemcpyAsync(mtp_kv_payload.data(), d_mtp_staging, total_plane_bytes,
-                                       cudaMemcpyDeviceToHost, device.stream));
-            CUDA_CHECK(cudaFreeAsync(d_mtp_staging, device.stream));
+            constexpr std::uint32_t kSaveBatchPages = 32;
+            const std::size_t mtp_page_bytes = mtp_pool.total_page_bytes();
+            for (std::size_t b = 0; b < valid_mtp_page_ids.size(); b += kSaveBatchPages) {
+                const std::size_t n =
+                    std::min<std::size_t>(kSaveBatchPages, valid_mtp_page_ids.size() - b);
+                const std::size_t batch_bytes = n * mtp_page_bytes;
+
+                void* d_mtp_staging = nullptr;
+                CUDA_CHECK(cudaMallocAsync(&d_mtp_staging, batch_bytes, device.stream));
+                mtp_pool.gather_to_contiguous_device(
+                    std::span<const std::int32_t>(valid_mtp_page_ids.data() + b, n),
+                    d_mtp_staging, device.stream);
+                CUDA_CHECK(cudaMemcpyAsync(mtp_kv_payload.data() + b * mtp_page_bytes, d_mtp_staging,
+                                           batch_bytes, cudaMemcpyDeviceToHost, device.stream));
+                CUDA_CHECK(cudaFreeAsync(d_mtp_staging, device.stream));
+            }
         }
     }
 
@@ -2645,20 +2698,38 @@ void ProgramImplCore::snapshot_turn_checkpoint_to_disk(std::uint32_t lane, DiskS
     void* h_text_pinned = nullptr;
     std::size_t missing_total_bytes = 0;
 
-    if (!missing_physical_page_ids.empty()) {
-        const auto& pool = decoder->text_kv.pool();
-        single_page_bytes = static_cast<std::uint32_t>(pool.total_page_bytes());
-        missing_total_bytes = pool.total_page_bytes() * missing_physical_page_ids.size();
+        if (!missing_physical_page_ids.empty()) {
+            const auto& pool = decoder->text_kv.pool();
+            single_page_bytes = static_cast<std::uint32_t>(pool.total_page_bytes());
+            missing_total_bytes = pool.total_page_bytes() * missing_physical_page_ids.size();
 
-        void* d_staging = nullptr;
-        CUDA_CHECK(cudaMallocAsync(&d_staging, missing_total_bytes, device.stream));
-        pool.gather_to_contiguous_device(missing_physical_page_ids, d_staging, device.stream);
+            // Chunked staging: gather page batches into bounded pinned buffers instead of one
+            // whole-snapshot allocation, so saving a large checkpoint cannot OOM device memory.
+            constexpr std::uint32_t kSaveBatchPages = 32;
+            missing_pages_data.resize(missing_total_bytes);
+            std::byte* batch_dst = missing_pages_data.data();
+            for (std::size_t b = 0; b < missing_physical_page_ids.size(); b += kSaveBatchPages) {
+                const std::size_t n =
+                    std::min<std::size_t>(kSaveBatchPages, missing_physical_page_ids.size() - b);
+                const std::size_t batch_bytes = n * single_page_bytes;
 
-        CUDA_CHECK(cudaMallocHost(&h_text_pinned, missing_total_bytes));
-        CUDA_CHECK(cudaMemcpyAsync(h_text_pinned, d_staging, missing_total_bytes,
-                                   cudaMemcpyDeviceToHost, device.stream));
-        CUDA_CHECK(cudaFreeAsync(d_staging, device.stream));
-    } else if (sequence.kv && sequence.kv->text.valid()) {
+                void* d_batch = nullptr;
+                CUDA_CHECK(cudaMallocAsync(&d_batch, batch_bytes, device.stream));
+                pool.gather_to_contiguous_device(
+                    std::span<const std::int32_t>(missing_physical_page_ids.data() + b, n),
+                    d_batch, device.stream);
+
+                void* h_batch = nullptr;
+                CUDA_CHECK(cudaMallocHost(&h_batch, batch_bytes));
+                CUDA_CHECK(cudaMemcpyAsync(h_batch, d_batch, batch_bytes,
+                                           cudaMemcpyDeviceToHost, device.stream));
+                CUDA_CHECK(cudaFreeAsync(d_batch, device.stream));
+                CUDA_CHECK(cudaStreamSynchronize(device.stream));
+                std::memcpy(batch_dst, h_batch, batch_bytes);
+                CUDA_CHECK(cudaFreeHost(h_batch));
+                batch_dst += batch_bytes;
+            }
+        } else if (sequence.kv && sequence.kv->text.valid()) {
         const auto& pool = decoder->text_kv.pool();
         single_page_bytes = static_cast<std::uint32_t>(pool.total_page_bytes());
     }
@@ -2681,12 +2752,22 @@ void ProgramImplCore::snapshot_turn_checkpoint_to_disk(std::uint32_t lane, DiskS
             const std::size_t total_plane_bytes = mtp_pool.total_page_bytes() * valid_mtp_page_ids.size();
             mtp_kv_payload.resize(total_plane_bytes);
 
-            void* d_mtp_staging = nullptr;
-            CUDA_CHECK(cudaMallocAsync(&d_mtp_staging, total_plane_bytes, device.stream));
-            mtp_pool.gather_to_contiguous_device(valid_mtp_page_ids, d_mtp_staging, device.stream);
-            CUDA_CHECK(cudaMemcpyAsync(mtp_kv_payload.data(), d_mtp_staging, total_plane_bytes,
-                                       cudaMemcpyDeviceToHost, device.stream));
-            CUDA_CHECK(cudaFreeAsync(d_mtp_staging, device.stream));
+            constexpr std::uint32_t kSaveBatchPages = 32;
+            const std::size_t mtp_page_bytes = mtp_pool.total_page_bytes();
+            for (std::size_t b = 0; b < valid_mtp_page_ids.size(); b += kSaveBatchPages) {
+                const std::size_t n =
+                    std::min<std::size_t>(kSaveBatchPages, valid_mtp_page_ids.size() - b);
+                const std::size_t batch_bytes = n * mtp_page_bytes;
+
+                void* d_mtp_staging = nullptr;
+                CUDA_CHECK(cudaMallocAsync(&d_mtp_staging, batch_bytes, device.stream));
+                mtp_pool.gather_to_contiguous_device(
+                    std::span<const std::int32_t>(valid_mtp_page_ids.data() + b, n),
+                    d_mtp_staging, device.stream);
+                CUDA_CHECK(cudaMemcpyAsync(mtp_kv_payload.data() + b * mtp_page_bytes, d_mtp_staging,
+                                           batch_bytes, cudaMemcpyDeviceToHost, device.stream));
+                CUDA_CHECK(cudaFreeAsync(d_mtp_staging, device.stream));
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

The persistent prompt cache (`--disk-cache`) allocates one staging buffer sized to the whole snapshot on both the save and restore paths:

- Restore: `cudaMallocAsync(&d_text_staging, loaded_text_kv.size())` — the entire snapshot's KV pages staged in device memory at once
- Save: `cudaMallocAsync(&d_staging, missing_total_bytes)` + `cudaMallocHost(&h_text_pinned, missing_total_bytes)` — the entire delta's pages staged at once

On a 24 GB card with a 280k-context configuration (`rk4v4-e8`, ~6.2 GiB KV pool, ~0.5 GiB free after startup), any snapshot beyond a few tens of thousands of tokens exceeds the free device memory and the server dies with:

```
program_impl.h:2654: CUDA_CHECK(cudaMallocAsync(&d_staging, missing_total_bytes, device.stream)) failed: cudaErrorMemoryAllocation: out of memory
```

Since the container runs with `--restart unless-stopped`, this turns into a crash-restore loop: every request hits the disk snapshot, restore fails, the process dies, the client sees the connection drop, and the retry repeats it.

## Fix

Process KV pages in bounded batches (32 pages per batch) instead of one whole-snapshot allocation, in all four staging sites:

- restore Text KV (`scatter`)
- restore MTP KV (`scatter`)
- save Text KV (`gather` → pinned host → payload)
- save MTP KV (`gather` → payload)

The gather/scatter kernels (`gather_paged_kv_kernel` / `scatter_paged_kv_kernel` in `kv_paged_staging.cuh`) address pages relative to the batch (`v_page = blockIdx.z`, `src_idx = v_page * plane.single_page_uint4s`), so batching against the existing page-major staging layout is layout-safe: each batch passes the corresponding page-id span and a staging pointer whose page 0 is the batch's first page.

## Verification (RTX 4090, Qwen3.8-27B, `rk4v4-e8`, 280k context, MTP3, vision, `--disk-cache`)

| operation | before | after |
|---|---|---|
| save 130k-token checkpoint (1.9 GiB) | `cudaErrorMemoryAllocation` crash | 351 ms, `saved CoW snapshot tokens=130054` |
| restore 130k-token checkpoint (2.4 GiB) after container restart | crash loop | 878 ms, `restore_disk_checkpoint`, `cached=130054` |
| TTFT after restart (130k prompt) | ~105 s full prefill / crash | 1.1 s |

No numerical contract changes: batch boundaries only split the same byte sequence; page order within the payload is unchanged.
