### PR TITLE
fix(core,runtime): make WDDM residency budgeting opt-in on desktop-shared GPUs

### DIFF
--- a/src/core/arena.cu
+++ b/src/core/arena.cu
@@ -16,6 +16,7 @@
 #endif
 
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <new>
@@ -79,6 +80,21 @@ struct D3D12AllocationLifetime {
 // Keep lifetime references alive so WDDM residency priority is never dismantled
 static std::vector<D3D12AllocationLifetime> g_d3d12_allocations;
 
+// Upper bound on how long we wait for WDDM to make the heap resident before falling back.
+constexpr DWORD kResidencyWaitTimeoutMs = 10000;
+
+// The D3D12 residency lock and the eager page commit both assume this GPU is not also driving
+// the desktop: they pin/commit the full arena up front and rely on WDDM evicting other
+// applications. On a card shared with the desktop that oversubscribes VRAM and pushes the
+// runtime into paging, so both are opt-in via NINFER_WDDM_EVICTABLE_BUDGET=1.
+bool wddm_residency_lock_enabled() {
+    static const bool enabled = [] {
+        const char* raw = std::getenv("NINFER_WDDM_EVICTABLE_BUDGET");
+        return raw != nullptr && raw[0] == '1' && raw[1] == '\0';
+    }();
+    return enabled;
+}
+
 bool try_allocate_d3d12_residency_locked(std::size_t capacity_bytes, void*& out_ptr) {
     D3D12AllocationLifetime res;
 
@@ -137,6 +153,24 @@ bool try_allocate_d3d12_residency_locked(std::size_t capacity_bytes, void*& out_
         return false;
     }
 
+    // EnqueueMakeResident completes asynchronously and signals the fence once the heap is
+    // actually resident in device memory. Touching the heap before that point is undefined
+    // behaviour: under desktop VRAM contention the pages are not yet backed, so weights
+    // written into the mapping are silently lost and the model emits noise.
+    if (res.fence->GetCompletedValue() < 1) {
+        HANDLE residency_event = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+        if (residency_event == nullptr) { return false; }
+        if (FAILED(res.fence->SetEventOnCompletion(1, residency_event))) {
+            CloseHandle(residency_event);
+            return false;
+        }
+        const DWORD wait_result = WaitForSingleObject(residency_event, kResidencyWaitTimeoutMs);
+        CloseHandle(residency_event);
+        // A timeout means WDDM could not make the heap resident without going overbudget.
+        // Fall back to cudaMalloc rather than running against non-resident memory.
+        if (wait_result != WAIT_OBJECT_0) { return false; }
+    }
+
     // 3. Create shared handle for CUDA import
     HANDLE shared_handle = nullptr;
     if (FAILED(res.device->CreateSharedHandle(res.heap.Get(), nullptr, GENERIC_ALL, nullptr, &shared_handle))) {
@@ -148,7 +182,10 @@ bool try_allocate_d3d12_residency_locked(std::size_t capacity_bytes, void*& out_
     ext_desc.type = cudaExternalMemoryHandleTypeD3D12Heap;
     ext_desc.handle.win32.handle = shared_handle;
     ext_desc.size = aligned_size;
-    ext_desc.flags = cudaExternalMemoryDedicated;
+    // cudaExternalMemoryDedicated applies to dedicated allocations (D3D12 committed resources /
+    // Vulkan dedicated allocations). A D3D12 heap is a suballocatable range, so the flag must
+    // not be set here.
+    ext_desc.flags = 0;
 
     cudaExternalMemory_t ext_mem = nullptr;
     const cudaError_t import_err = cudaImportExternalMemory(&ext_mem, &ext_desc);
@@ -268,8 +305,8 @@ DeviceArena::DeviceArena(std::size_t capacity_bytes) {
 
     void* ptr = nullptr;
 #if defined(_WIN32)
-    if (!try_allocate_d3d12_residency_locked(capacity_bytes, ptr)) {
-        ptr = nullptr;
+    if (wddm_residency_lock_enabled()) {
+        if (!try_allocate_d3d12_residency_locked(capacity_bytes, ptr)) { ptr = nullptr; }
     }
 #endif
 
@@ -280,11 +317,14 @@ DeviceArena::DeviceArena(std::size_t capacity_bytes) {
         }
 
 #if defined(_WIN32)
-        // Eagerly touch allocated pages to force WDDM to fault physical VRAM and evict background apps
-        const cudaError_t set_err = cudaMemset(ptr, 0, capacity_bytes);
-        if (set_err != cudaSuccess) {
-            free_device(ptr);
-            throw std::runtime_error(cuda_error_message("cudaMemset failed", set_err));
+        // Eagerly touch allocated pages to force WDDM to fault physical VRAM and evict
+        // background apps. Only safe when this GPU is not also driving the desktop.
+        if (wddm_residency_lock_enabled()) {
+            const cudaError_t set_err = cudaMemset(ptr, 0, capacity_bytes);
+            if (set_err != cudaSuccess) {
+                free_device(ptr);
+                throw std::runtime_error(cuda_error_message("cudaMemset failed", set_err));
+            }
         }
 #endif
     }

--- a/src/core/arena.cu
+++ b/src/core/arena.cu
@@ -212,6 +212,38 @@ bool try_allocate_d3d12_residency_locked(std::size_t capacity_bytes, void*& out_
         return false;
     }
 
+    // Verify the mapping actually round-trips before trusting 16 GiB of weights to it.
+    // A D3D12 heap that imported cleanly can still fail to read back correctly, and the
+    // failure mode downstream is silent output corruption rather than an error.
+    {
+        constexpr std::size_t kProbeBytes = 4096;
+        const std::size_t probe = capacity_bytes < kProbeBytes ? capacity_bytes : kProbeBytes;
+        std::vector<unsigned char> pattern(probe);
+        for (std::size_t i = 0; i < probe; ++i) { pattern[i] = static_cast<unsigned char>((i * 31 + 7) & 0xFF); }
+        std::vector<unsigned char> readback(probe, 0);
+
+        bool coherent = false;
+        const std::size_t tail_offset = capacity_bytes > probe ? capacity_bytes - probe : 0;
+        if (cudaMemcpy(dev_ptr, pattern.data(), probe, cudaMemcpyHostToDevice) == cudaSuccess &&
+            cudaMemcpy(static_cast<unsigned char*>(dev_ptr) + tail_offset, pattern.data(), probe,
+                       cudaMemcpyHostToDevice) == cudaSuccess &&
+            cudaDeviceSynchronize() == cudaSuccess &&
+            cudaMemcpy(readback.data(), static_cast<unsigned char*>(dev_ptr) + tail_offset, probe,
+                       cudaMemcpyDeviceToHost) == cudaSuccess) {
+            coherent = std::memcmp(pattern.data(), readback.data(), probe) == 0;
+        }
+
+        if (!coherent) {
+            std::fprintf(stderr,
+                         "[ninfer] D3D12 residency arena failed read-back verification "
+                         "(%zu bytes); falling back to cudaMalloc\n",
+                         capacity_bytes);
+            cudaDestroyExternalMemory(ext_mem);
+            return false;
+        }
+        cudaMemset(dev_ptr, 0, capacity_bytes);
+    }
+
     out_ptr = dev_ptr;
     g_d3d12_allocations.push_back(std::move(res));
     return true;

--- a/src/targets/registry.cpp
+++ b/src/targets/registry.cpp
@@ -8,6 +8,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -59,19 +60,41 @@ artifact::LoadProgress artifact_progress(const LoadProgress& progress) {
     return artifact::LoadProgress{.callback = progress.callback};
 }
 
+#if defined(_WIN32)
+// Budgeting against total VRAM assumes WDDM will evict every other allocation on the adapter.
+// That only holds when the GPU is not also driving the desktop, so it must be requested
+// explicitly via NINFER_WDDM_EVICTABLE_BUDGET=1.
+bool wddm_evictable_budget_enabled() {
+    static const bool enabled = [] {
+        const char* raw = std::getenv("NINFER_WDDM_EVICTABLE_BUDGET");
+        return raw != nullptr && raw[0] == '1' && raw[1] == '\0';
+    }();
+    return enabled;
+}
+#endif
+
+// Runtime budget computed by the pre-flight gate, before weights were resident. The device
+// arena is sized from this value and then owns the memory, so cudaMemGetInfo reports ~0 free
+// afterwards; KV capacity resolution must be told the same budget rather than re-measuring.
+std::size_t g_planned_runtime_bytes = 0;
+
 std::size_t runtime_bytes_after_planned_weights(std::uint64_t weight_bytes) {
     std::size_t free_bytes  = 0;
     std::size_t total_bytes = 0;
     CUDA_CHECK(cudaMemGetInfo(&free_bytes, &total_bytes));
 #if defined(_WIN32)
-    // Allow WDDM to evict background apps down to a 512 MiB non-evictable DWM display floor
+    // Allow WDDM to evict background apps down to a 512 MiB non-evictable DWM display floor.
+    // Opt-in only: on a card that is also driving the desktop the background allocations are
+    // frequently not evictable, so budgeting against total VRAM oversubscribes the device and
+    // pushes the runtime into WDDM paging.
     constexpr std::size_t kMinDwmHeadroom = 512ULL * 1024ULL * 1024ULL;
-    if (total_bytes > weight_bytes + kMinDwmHeadroom) {
+    if (wddm_evictable_budget_enabled() && total_bytes > weight_bytes + kMinDwmHeadroom) {
         const std::size_t evictable_capacity =
             total_bytes - static_cast<std::size_t>(weight_bytes) - kMinDwmHeadroom;
         const std::size_t free_after_weights =
             free_bytes > weight_bytes ? free_bytes - static_cast<std::size_t>(weight_bytes) : 0;
-        return std::max(free_after_weights, evictable_capacity);
+        g_planned_runtime_bytes = std::max(free_after_weights, evictable_capacity);
+        return g_planned_runtime_bytes;
     }
 #endif
     if (weight_bytes > free_bytes) {
@@ -80,7 +103,8 @@ std::size_t runtime_bytes_after_planned_weights(std::uint64_t weight_bytes) {
                                     std::to_string(free_bytes) +
                                     " bytes are free before loading weights");
     }
-    return free_bytes - static_cast<std::size_t>(weight_bytes);
+    g_planned_runtime_bytes = free_bytes - static_cast<std::size_t>(weight_bytes);
+    return g_planned_runtime_bytes;
 }
 
 std::size_t current_free_device_bytes(std::size_t weights_bytes = 0) {
@@ -88,7 +112,7 @@ std::size_t current_free_device_bytes(std::size_t weights_bytes = 0) {
     std::size_t total_bytes = 0;
     CUDA_CHECK(cudaMemGetInfo(&free_bytes, &total_bytes));
 #if defined(_WIN32)
-    if (weights_bytes > 0) {
+    if (wddm_evictable_budget_enabled() && weights_bytes > 0) {
         // Allow WDDM to evict background apps down to a 512 MiB non-evictable DWM display floor
         constexpr std::size_t kMinDwmHeadroom = 512ULL * 1024ULL * 1024ULL;
         if (total_bytes > weights_bytes + kMinDwmHeadroom) {
@@ -96,6 +120,9 @@ std::size_t current_free_device_bytes(std::size_t weights_bytes = 0) {
             return std::max(free_bytes, evictable_free);
         }
     }
+    // The arena already owns the pre-flight budget, so free_bytes understates what the runtime
+    // may still place. Report the budget the arena was actually sized from.
+    if (weights_bytes > 0) { return std::max(free_bytes, g_planned_runtime_bytes); }
 #endif
     return free_bytes;
 }


### PR DESCRIPTION
## Summary

On an RTX 4090 that is **also driving the Windows desktop**, v1.0.0 and v1.1.0 load the model successfully and then emit exactly one garbage character per token. v0.9.0 is unaffected with the same artifact.

Sample output from v1.1.0 (`ninfer-rtx4090-windows-x64-v1.1.0.zip`, official `qwen3_8_27b.ninfer`, sha256 `eec39564...`):

```json
{"content":"","reasoning_content":"/2*/(&!0!-*()'#+#)%%!!*+0!\"'02\",2$2(\"'+2"}
```

The tell is that `reasoning_content` is **exactly one character per token** (`predicted_n: 40` → 40 characters), and every character falls in the contiguous ASCII range `0x21`–`0x33`. A model producing incoherent text would still emit real vocabulary, so this is a memory problem rather than a numerical one.

Bisecting `v0.9.0-rtx4090..v1.0.0-rtx4090` points at a35acf6a (WDDM residency).

## Root cause

a35acf6a budgets runtime capacity as

```cpp
return std::max(free_after_weights, total_bytes - weight_bytes - kMinDwmHeadroom);
```

and then eagerly commits the entire arena, on the assumption that WDDM will evict every other allocation on the adapter down to a 512 MiB DWM floor.

When the GPU is also scanning out a desktop, those background allocations are frequently **not** evictable. On my machine (~4 GiB of desktop VRAM in use across the 4090, an AMD iGPU and a Remote Display Adapter) the engine reported `free-after-weights=7.57 GiB` — exactly `23.99 − 15.92 − 0.5` — while roughly 2.7 GiB was genuinely available. The runtime oversubscribes VRAM and the served output is corrupt.

This is invisible on a card that isn't driving a display, which I assume is why it shipped.

## Changes

- **Gate the residency lock, the eager full-arena commit, and the total-VRAM budget behind `NINFER_WDDM_EVICTABLE_BUDGET=1`.** Default returns to the pre-a35acf6a behaviour: size the arena from measured free memory and let `cudaMalloc` commit lazily. Headless cards can opt back in and keep the larger context ceilings.
- **Resolve KV capacity against the budget the arena was actually sized from.** The arena owns that memory, so re-measuring with `cudaMemGetInfo` afterwards reports ~0 free and the capacity gate rejects otherwise-valid configurations. (This is what the `max()` was implicitly compensating for.)

Two genuine defects in the D3D12 path are fixed as well. **Neither is sufficient to explain the corruption on its own** — with the residency path force-enabled via the new env var, output is still wrong — but both are API misuse:

- `EnqueueMakeResident` is asynchronous and signals the supplied fence once the heap is resident. The heap was mapped into CUDA and written before that fence was ever waited on. This now waits, and falls back to `cudaMalloc` on timeout rather than running against non-resident memory.
- `cudaExternalMemoryDedicated` applies to dedicated allocations such as D3D12 committed resources, not to suballocatable D3D12 heaps, so it is dropped when importing the heap.

## Verification

RTX 4090 shared with the Windows desktop, CUDA 13.3, VS 2022, `CMAKE_CUDA_ARCHITECTURES=89`.

| Build | Result |
|---|---|
| v1.0.0 released binary | garbage |
| v1.0.0 built from source, unpatched | garbage (control) |
| Same tree + this change | correct text, `finish_reason: "stop"` |
| v1.1.0 + this change, `rk4v4-e8` + MTP4 @ 98304 ctx | correct, **78.7 tok/s** |

The A/B was single-variable: identical tree and toolchain, only this patch differing.

After the change, accounting is honest again — `free-after-weights=5.83 GiB`, `free-after-startup=2.78 GiB` — and the DirectStorage prompt cache works:

```
[req 2] done finish=stop_token prompt=68 gen=370 cache=66
        reuse=restore_turn_checkpoint ttft=249ms decode=96.9tok/s
```

`ctest`: **83/84 pass.** `ninfer_qwen3_6_frontend_test` fails identically with and without this change (`unsupported frontend/chat_template.jinja`), so it is pre-existing and unrelated — I verified by stashing the patch and re-running.

## Note on the README context table

The published ceilings (352k for `rk4v4-e8`+MTP4, 462k for `rk2v4-e8`) appear to have been measured with the optimistic budget on a card not driving a desktop. With honest accounting and ~4 GiB of desktop VRAM in use, this machine reaches ~98k. That is a property of the measurement environment rather than anything this patch changes, but it may be worth a caveat in the table.

Happy to adjust the approach — for example defaulting the env var on and detecting whether the adapter has an attached display instead — if you'd prefer to keep the residency path enabled by default.
