### PR TITLE
fix(arena): drain WDDM touch-fill before arena pointers are published

### DIFF
--- a/src/core/arena.cu
+++ b/src/core/arena.cu
@@ -237,6 +237,15 @@ bool try_allocate_d3d12_residency_locked(std::size_t capacity_bytes, void*& out_
         cudaMemset(dev_ptr, 0, capacity_bytes);
     }
 
+    // The final zero-fill above is enqueued on the legacy default stream, which does not order
+    // against non-blocking streams such as DeviceContext::load_stream. Wait for it to land so
+    // stream-ordered weight copies cannot be wiped by the fill (silent all-zero weights).
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+        cudaFree(dev_ptr);
+        cudaDestroyExternalMemory(ext_mem);
+        return false;
+    }
+
     out_ptr = dev_ptr;
     g_d3d12_allocations.push_back(std::move(res));
     return true;
@@ -362,6 +371,14 @@ DeviceArena::DeviceArena(std::size_t capacity_bytes) {
                 free_device(ptr);
                 throw std::runtime_error(cuda_error_message("cudaMemset failed", set_err));
             }
+            // The touch is enqueued on the legacy default stream, which does not order against
+            // non-blocking streams such as DeviceContext::load_stream. Wait for it to land so
+            // stream-ordered weight copies cannot be wiped by the fill.
+            const cudaError_t sync_err = cudaDeviceSynchronize();
+            if (sync_err != cudaSuccess) {
+                free_device(ptr);
+                throw std::runtime_error(cuda_error_message("cudaDeviceSynchronize failed", sync_err));
+            }
         }
 #endif
     }
@@ -462,9 +479,9 @@ PinnedHostBuffer::PinnedHostBuffer(std::size_t size_bytes) {
     if (size_bytes == 0) { throw std::invalid_argument("PinnedHostBuffer size must be nonzero"); }
 
     void* ptr             = nullptr;
-    const cudaError_t err = cudaHostAlloc(&ptr, size_bytes, cudaHostAllocWriteCombined);
+    const cudaError_t err = cudaMallocHost(&ptr, size_bytes);
     if (err != cudaSuccess) {
-        throw std::runtime_error(cuda_error_message("cudaHostAlloc failed", err));
+        throw std::runtime_error(cuda_error_message("cudaMallocHost failed", err));
     }
 
     data_ = ptr;


### PR DESCRIPTION
Follow-up to #7 — @keylimesoda, great catch with the round-trip probe; that read-back verification is exactly what this code needed. One heads-up from my side: after the probe, there are still two fills with no ordering against non-blocking streams, and I hit a nasty silent bug through one of them on an RTX 4090 (constant token-0 output, every sanitizer clean).

**What's left:**

1. The **final full-capacity zero-fill** at the end of `try_allocate_d3d12_residency_locked` — the probe's `cudaDeviceSynchronize()` drains the *first* touch, but this last fill is enqueued on the legacy default stream and the function returns without draining it.
2. The **fallback `cudaMalloc` path's touch fill** in `DeviceArena::DeviceArena` has no sync at all.

Since the legacy default stream does not order against non-blocking streams like `DeviceContext::load_stream`, async H2D weight copies can land *before* either of these fills and get wiped to `0x00`. Failure mode: all-zero device weights → uniform logits → the model emits token 0 for every prompt, load stats look perfect (16.67 GiB / 100%), and compute-sanitizer memcheck/racecheck/synccheck are all clean — it's an ordering race between two legal operations, not a memory error.

**The change:** `cudaDeviceSynchronize()` after the final D3D12 zero-fill (failure path frees the imported external memory) and after the fallback touch — 19 insertions / 2 deletions in `src/core/arena.cu`, plus a `PinnedHostBuffer` write-combined → `cudaMallocHost` swap I verified alongside. The branch sits directly on top of #7's merge, so this should apply cleanly.

**Verified:** Windows 11 · RTX 4090 · CUDA 13.3 — `ninfer_artifact_materialization_test` passes (it read back `0x00` where artifact data belongs before the fix), qwen3_8_27b generates coherent output at ~35 tok/s decode.