### PR TITLE
feat(serve): add MTP-compatible structured JSON output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ endif()
 
 project(ninfer LANGUAGES C CXX CUDA)
 
+include(FetchContent)
+
 # --- Global settings ---------------------------------------------------------
 option(NINFER_BUILD_APPS "Build the NInfer CLI and server" ON)
 option(BUILD_TESTING "Build NInfer tests" OFF)
@@ -136,7 +138,6 @@ if(NINFER_BUILD_SERVE)
 endif()
 
 if(WIN32)
-  include(FetchContent)
   FetchContent_Declare(
     directstorage
     URL "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.DirectStorage/1.3.0"
@@ -159,6 +160,37 @@ if(WIN32)
     "${directstorage_SOURCE_DIR}/native/bin/x64/dstoragecore.dll"
   )
 endif()
+
+# XGrammar provides the tokenizer-aware automaton used by structured generation. Define the
+# library locally instead of adding its top-level project: upstream's project-wide compiler flags
+# must not leak into NInfer's CUDA build.
+FetchContent_Declare(
+  xgrammar_source
+  GIT_REPOSITORY https://github.com/mlc-ai/xgrammar.git
+  GIT_TAG v0.2.5.post1
+  GIT_SHALLOW TRUE
+  GIT_SUBMODULES 3rdparty/dlpack
+)
+FetchContent_GetProperties(xgrammar_source)
+if(NOT xgrammar_source_POPULATED)
+  cmake_policy(PUSH)
+  cmake_policy(SET CMP0169 OLD)
+  FetchContent_Populate(xgrammar_source)
+  cmake_policy(POP)
+endif()
+file(GLOB_RECURSE NINFER_XGRAMMAR_SOURCES CONFIGURE_DEPENDS
+  "${xgrammar_source_SOURCE_DIR}/cpp/*.cc")
+list(FILTER NINFER_XGRAMMAR_SOURCES EXCLUDE REGEX "/cpp/tvm_ffi/.*\\.cc$")
+add_library(ninfer_xgrammar STATIC ${NINFER_XGRAMMAR_SOURCES})
+target_compile_features(ninfer_xgrammar PUBLIC cxx_std_20)
+target_compile_definitions(ninfer_xgrammar PUBLIC
+  XGRAMMAR_ENABLE_CPPTRACE=0
+  XGRAMMAR_ENABLE_INTERNAL_CHECK=0)
+target_include_directories(ninfer_xgrammar
+  PUBLIC "${xgrammar_source_SOURCE_DIR}/include"
+  SYSTEM PUBLIC
+    "${xgrammar_source_SOURCE_DIR}/3rdparty/picojson"
+    "${xgrammar_source_SOURCE_DIR}/3rdparty/dlpack/include")
 
 # --- Subdirectories ----------------------------------------------------------
 add_subdirectory(src)

--- a/include/ninfer/ops/sampling.h
+++ b/include/ninfer/ops/sampling.h
@@ -30,6 +30,8 @@ struct SamplingConfig {
     float frequency_penalty    = 0.0f;
     unsigned long long seed    = 0;
     std::int32_t* token_counts = nullptr; // device [token_domain] i32, or null
+    const std::uint32_t* token_mask = nullptr; // device ceil(token_domain/32) bitset, or null
+    bool disable_speculation = false;
 };
 
 // Caller-owned transient capacity for every parallel sampling-lane count in the inclusive

--- a/include/ninfer/types.h
+++ b/include/ninfer/types.h
@@ -169,10 +169,28 @@ struct OutputOptions {
     bool preserve_special_tokens = false;
 };
 
+enum class StructuredOutputMode : std::uint8_t {
+    None,
+    JsonObject,
+    JsonSchema,
+};
+
+// Describes a token-level output language. The target frontend compiles this against its exact
+// tokenizer; the runtime then applies the resulting token mask before every sampling decision.
+struct StructuredOutputOptions {
+    StructuredOutputMode mode = StructuredOutputMode::None;
+    std::string name;
+    std::string schema_json;
+    bool strict = false;
+
+    [[nodiscard]] bool enabled() const noexcept { return mode != StructuredOutputMode::None; }
+};
+
 struct RequestOptions {
     ExecutionOptions execution;
     StopPolicy stop;
     OutputOptions output;
+    StructuredOutputOptions structured_output;
 };
 
 // Owns a bounded host-input reservation whose lifetime may cross from request preparation into

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -276,7 +276,8 @@ target_link_libraries(ninfer_engine
     ninfer_core
     ninfer_ops
     ninfer_text
-    ninfer_media_decode)
+    ninfer_media_decode
+    ninfer_xgrammar)
 add_library(ninfer::engine ALIAS ninfer_engine)
 
 if(NINFER_BUILD_SERVE)

--- a/src/ops/kernel/sampling.cuh
+++ b/src/ops/kernel/sampling.cuh
@@ -29,7 +29,8 @@ __launch_bounds__(kSamplerBlock) __global__
         float bv = -CUDART_INF_F;
         int bi   = INT_MAX;
         for (int v = tid; v < token_domain; v += blockDim.x) {
-            const float x = __bfloat162float(logits[base + v]);
+            const float raw = __bfloat162float(logits[base + v]);
+            const float x   = sampling_token_allowed(v, cfg) ? raw : -CUDART_INF_F;
             if (sampling_better(x, v, bv, bi)) {
                 bv = x;
                 bi = v;
@@ -111,7 +112,8 @@ __launch_bounds__(kSamplerBlock) __global__
         const int v = tile_start + item * blockDim.x + threadIdx.x;
         if (v < token_domain) {
             const float raw = __bfloat162float(logits[base + v]);
-            const float x   = greedy ? raw : sampling_adjusted_logit(raw, v, cfg);
+            const float x   = greedy ? (sampling_token_allowed(v, cfg) ? raw : -CUDART_INF_F)
+                                     : sampling_adjusted_logit(raw, v, cfg);
             keys[item]      = sampling_sort_key(x, v);
         } else {
             keys[item] = 0ull;

--- a/src/ops/kernel/sampling_device.cuh
+++ b/src/ops/kernel/sampling_device.cuh
@@ -134,9 +134,16 @@ __device__ __forceinline__ int sampling_dist_offset(int col, int j) {
 // the penalty at each column sees the same prefix a per-token sampler would.
 // Non-speculative callers pass no overlay. The scan is bounded by k and
 // only runs when penalties are active, so it is free on the no-penalty path.
+__device__ __forceinline__ bool sampling_token_allowed(int v, const SamplingConfig& c) {
+    return c.token_mask == nullptr ||
+           (c.token_mask[static_cast<unsigned int>(v) >> 5] &
+            (1U << (static_cast<unsigned int>(v) & 31U))) != 0U;
+}
+
 __device__ __forceinline__ float sampling_adjusted_logit(float raw, int v, const SamplingConfig& c,
                                                          const std::int32_t* overlay = nullptr,
                                                          int overlay_len             = 0) {
+    if (!sampling_token_allowed(v, c)) { return -CUDART_INF_F; }
     float x = raw;
     if (c.presence_penalty == 0.0f && c.frequency_penalty == 0.0f) { return x; }
     int cnt = c.token_counts != nullptr ? c.token_counts[v] : 0;

--- a/src/ops/kernel/speculative_round.cuh
+++ b/src/ops/kernel/speculative_round.cuh
@@ -168,14 +168,17 @@ __launch_bounds__(kSamplerBlock) __global__ void speculative_accept_greedy_draft
     for (int i = 0; i <= extent; ++i) {
         // Column i is only reached when drafts[0..i-1] were all accepted, so the
         // round-local penalty overlay for this column is exactly those i drafts.
+        SamplingConfig column_cfg = cfg;
+        if (i != 0) { column_cfg.token_mask = nullptr; }
         const std::int64_t base = static_cast<std::int64_t>(i) * physical_rows;
         if (token_domain <= kSamplerTileItems) {
-            sampling_build_truncated_small(row_logits, base, token_domain, cfg, red_val, red_idx,
-                                           cand_val, cand_idx, prob, &n_support, row_drafts, i);
+            sampling_build_truncated_small(row_logits, base, token_domain, column_cfg, red_val,
+                                           red_idx, cand_val, cand_idx, prob, &n_support,
+                                           row_drafts, i);
         } else {
-            sampling_build_truncated_block_fast(row_logits, base, token_domain, cfg, merge_val,
-                                                merge_idx, cand_val, cand_idx, prob, &n_support,
-                                                row_drafts, i);
+            sampling_build_truncated_block_fast(row_logits, base, token_domain, column_cfg,
+                                                merge_val, merge_idx, cand_val, cand_idx, prob,
+                                                &n_support, row_drafts, i);
         }
         if (tid == 0 && done_sh == 0) {
             const int L = L_sh;
@@ -241,7 +244,8 @@ __launch_bounds__(kSamplerBlock) __global__ void speculative_sampling_partial_to
     int extent        = current_extents[row];
     extent            = extent < 0 ? 0 : (extent > k ? k : extent);
     if (col > extent) { return; }
-    const SamplingConfig cfg = configs[row];
+    SamplingConfig cfg = configs[row];
+    if (col != 0) { cfg.token_mask = nullptr; }
     if (!(cfg.temperature > 0.0f) || token_domain <= kSamplerTileItems) { return; }
     workspace = speculative_workspace_row(workspace, workspace_row_stride, row);
     if (partial == 0 && threadIdx.x == 0) {

--- a/src/ops/kernel/speculative_round.cuh
+++ b/src/ops/kernel/speculative_round.cuh
@@ -15,6 +15,34 @@
 
 namespace ninfer::ops {
 
+__device__ inline std::int32_t speculative_masked_argmax(const __nv_bfloat16* logits,
+                                                         std::int32_t token_domain,
+                                                         const SamplingConfig& cfg,
+                                                         float* values, int* indices) {
+    float best = -CUDART_INF_F;
+    int best_i = 0;
+    for (int v = threadIdx.x; v < token_domain; v += blockDim.x) {
+        const float value = sampling_adjusted_logit(__bfloat162float(logits[v]), v, cfg);
+        if (sampling_better(value, v, best, best_i)) {
+            best = value;
+            best_i = v;
+        }
+    }
+    values[threadIdx.x] = best;
+    indices[threadIdx.x] = best_i;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride != 0; stride >>= 1) {
+        if (threadIdx.x < stride &&
+            sampling_better(values[threadIdx.x + stride], indices[threadIdx.x + stride],
+                            values[threadIdx.x], indices[threadIdx.x])) {
+            values[threadIdx.x] = values[threadIdx.x + stride];
+            indices[threadIdx.x] = indices[threadIdx.x + stride];
+        }
+        __syncthreads();
+    }
+    return indices[0];
+}
+
 __global__ void speculative_prepare_verify_inputs_kernel(const std::int32_t* anchors,
                                                          const std::int32_t* drafts,
                                                          const std::int32_t* base_positions,
@@ -87,11 +115,18 @@ __launch_bounds__(kSamplerBlock) __global__ void speculative_accept_greedy_draft
     const __nv_bfloat16* row_logits =
         logits + static_cast<std::int64_t>(row) * cols * physical_rows;
 
+    __shared__ float red_val[kSamplerBlock];
+    __shared__ int red_idx[kSamplerBlock];
+
     if (!(cfg.temperature > 0.0f)) {
+        int first_target = row_targets[0];
+        if (cfg.token_mask != nullptr) {
+            first_target = speculative_masked_argmax(row_logits, token_domain, cfg, red_val, red_idx);
+        }
         if (tid == 0) {
             int a = 0;
-            while (a < extent && row_targets[a] == row_drafts[a]) { ++a; }
-            const int t_star = row_targets[a];
+            while (a < extent && (a == 0 ? first_target : row_targets[a]) == row_drafts[a]) { ++a; }
+            const int t_star = a == 0 ? first_target : row_targets[a];
 
             for (int i = 0; i <= k; ++i) { row_tokens[i] = 0; }
             for (int i = 0; i < a; ++i) { row_tokens[i] = row_drafts[i]; }
@@ -106,8 +141,6 @@ __launch_bounds__(kSamplerBlock) __global__ void speculative_accept_greedy_draft
         return;
     }
 
-    __shared__ float red_val[kSamplerBlock];
-    __shared__ int red_idx[kSamplerBlock];
     __shared__ float cand_val[kSamplerCandidateCap];
     __shared__ int cand_idx[kSamplerCandidateCap];
     __shared__ float prob[kSamplerCandidateCap];
@@ -250,10 +283,11 @@ __launch_bounds__(kSamplerBlock) __global__ void speculative_sampling_partial_to
 }
 
 __launch_bounds__(kSamplerGroupBlock) __global__ void speculative_sampling_group_finalize_kernel(
-    const std::int32_t* target_tokens, const std::int32_t* drafts,
+    const std::int32_t* target_tokens, const __nv_bfloat16* logits, const std::int32_t* drafts,
     const std::int32_t* current_extents, std::int32_t* lengths, std::int32_t* anchors,
     std::int32_t* licensed_tokens, std::int32_t* licensed_counts, std::int32_t* accepted,
-    const SamplingConfig* configs, std::int32_t token_domain, std::int32_t cols,
+    const SamplingConfig* configs, std::int32_t token_domain, std::int32_t physical_rows,
+    std::int32_t cols,
     std::int32_t partial_blocks, std::int32_t group_count, SamplingWorkspace workspace,
     std::size_t workspace_row_stride) {
     const int row   = static_cast<int>(blockIdx.z);
@@ -268,13 +302,22 @@ __launch_bounds__(kSamplerGroupBlock) __global__ void speculative_sampling_group
     const std::int32_t* row_targets = target_tokens + row * cols;
     const std::int32_t* row_drafts  = drafts + row * k;
     std::int32_t* row_tokens        = licensed_tokens + row * cols;
+    const __nv_bfloat16* row_logits =
+        logits + static_cast<std::int64_t>(row) * cols * physical_rows;
+    __shared__ float greedy_val[kSamplerGroupBlock];
+    __shared__ int greedy_idx[kSamplerGroupBlock];
     if (token_domain <= kSamplerTileItems) { return; }
 
     if (!(cfg.temperature > 0.0f)) {
+        int first_target = row_targets[0];
+        if (col == 0 && group == 0 && cfg.token_mask != nullptr) {
+            first_target = speculative_masked_argmax(
+                row_logits, token_domain, cfg, greedy_val, greedy_idx);
+        }
         if (tid == 0 && col == 0 && group == 0) {
             int a = 0;
-            while (a < extent && row_targets[a] == row_drafts[a]) { ++a; }
-            const int t_star = row_targets[a];
+            while (a < extent && (a == 0 ? first_target : row_targets[a]) == row_drafts[a]) { ++a; }
+            const int t_star = a == 0 ? first_target : row_targets[a];
             for (int i = 0; i <= k; ++i) { row_tokens[i] = 0; }
             for (int i = 0; i < a; ++i) { row_tokens[i] = row_drafts[i]; }
             row_tokens[a]        = t_star;

--- a/src/ops/launcher/speculative_round.cu
+++ b/src/ops/launcher/speculative_round.cu
@@ -89,12 +89,13 @@ void speculative_accept_greedy_drafts_launch(const Tensor& target_tokens, const 
     speculative_sampling_group_finalize_kernel<<<batched_group_grid, kSamplerGroupBlock, 0,
                                                  stream>>>(
         static_cast<const std::int32_t*>(target_tokens.data),
+        static_cast<const __nv_bfloat16*>(logits.data),
         static_cast<const std::int32_t*>(drafts.data),
         static_cast<const std::int32_t*>(current_extents.data),
         static_cast<std::int32_t*>(lengths.data), static_cast<std::int32_t*>(anchors.data),
         static_cast<std::int32_t*>(licensed_tokens.data),
         static_cast<std::int32_t*>(licensed_counts.data), static_cast<std::int32_t*>(accepted.data),
-        configs, token_domain, cols, partial_blocks, groups, scratch, layout.bytes);
+        configs, token_domain, physical_rows, cols, partial_blocks, groups, scratch, layout.bytes);
     CUDA_CHECK(cudaGetLastError());
 }
 

--- a/src/runtime/contract/types.h
+++ b/src/runtime/contract/types.h
@@ -23,12 +23,15 @@ struct ResolvedExecutionOptions {
     ResolvedSamplingParameters sampling;
     std::uint32_t requested_output_tokens = 0;
     bool allow_prefix_reuse               = true;
+    std::vector<std::uint32_t> token_mask;
+    bool disable_speculation = false;
 };
 
 struct ResolvedRequestOptions {
     ResolvedExecutionOptions execution;
     StopPolicy stop;
     OutputOptions output;
+    StructuredOutputOptions structured_output;
 };
 
 struct OutputDecision {

--- a/src/runtime/engine/concurrent_executor.h
+++ b/src/runtime/engine/concurrent_executor.h
@@ -722,7 +722,6 @@ private:
             if (request->output.has_token_constraint()) {
                 const auto mask = request->output.next_token_bitmask();
                 request->options.execution.token_mask.assign(mask.begin(), mask.end());
-                request->options.execution.disable_speculation = true;
             }
             request->base_plan.emplace(
                 instance_.program->plan_request_base(request->prompt, request->options.execution));
@@ -1097,8 +1096,7 @@ private:
             }
             const OutputDecision decision = request->output.preview(
                 row_tokens, request->budget->remaining(), request->budget->limit_reason());
-            if (decision.accepted_tokens == 0 || decision.accepted_tokens > count ||
-                (!decision.finished() && decision.accepted_tokens != count)) {
+            if (decision.accepted_tokens == 0 || decision.accepted_tokens > count) {
                 throw std::logic_error("output policy returned an invalid licensed prefix");
             }
             accepted[row]       = decision.accepted_tokens;

--- a/src/runtime/engine/concurrent_executor.h
+++ b/src/runtime/engine/concurrent_executor.h
@@ -162,7 +162,8 @@ public:
         std::shared_ptr<Request> request;
         try {
             auto output = instance_.loaded->frontend.make_output_session(prompt, options.stop,
-                                                                         options.output);
+                                                                         options.output,
+                                                                         options.structured_output);
             request = std::make_shared<Request>(request_id, std::move(prompt), std::move(output),
                                                 prompt_summary, prepare_seconds, std::move(options),
                                                 pending_deadline, submitted, std::move(host_input));
@@ -521,6 +522,9 @@ private:
             complete_success(request, decision.finish_reason);
             return true;
         }
+        if (request->output.has_token_constraint()) {
+            instance_.program->set_token_mask_lane(lane, request->output.next_token_bitmask());
+        }
         return false;
     }
 
@@ -715,6 +719,11 @@ private:
 
     void ensure_base_plan(const std::shared_ptr<Request>& request) {
         if (!request->base_plan) {
+            if (request->output.has_token_constraint()) {
+                const auto mask = request->output.next_token_bitmask();
+                request->options.execution.token_mask.assign(mask.begin(), mask.end());
+                request->options.execution.disable_speculation = true;
+            }
             request->base_plan.emplace(
                 instance_.program->plan_request_base(request->prompt, request->options.execution));
         }
@@ -1121,6 +1130,9 @@ private:
             if (terminal[row]) {
                 complete_success(request, finish_reasons[row]);
                 remove_completed_slot(lane);
+            } else if (request->output.has_token_constraint()) {
+                instance_.program->set_token_mask_lane(lane,
+                                                       request->output.next_token_bitmask());
             }
         }
         ++cumulative_stats_.decode_rounds;

--- a/src/runtime/engine/engine.cpp
+++ b/src/runtime/engine/engine.cpp
@@ -23,6 +23,7 @@ runtime::ResolvedRequestOptions resolve_request_options(const ModelSamplingDefau
     resolved.execution.allow_prefix_reuse      = options.execution.allow_prefix_reuse;
     resolved.stop                              = std::move(options.stop);
     resolved.output                            = options.output;
+    resolved.structured_output                 = std::move(options.structured_output);
     return resolved;
 }
 

--- a/src/serve/openai_schema.cpp
+++ b/src/serve/openai_schema.cpp
@@ -459,19 +459,55 @@ void reject_unsupported_features(const Json& body) {
             throw ApiException(std::move(error));
         }
     }
-    if (body.contains("response_format") && !body.at("response_format").is_null()) {
-        const Json& fmt  = body.at("response_format");
-        std::string type = fmt.is_object() && fmt.contains("type") && fmt.at("type").is_string()
-                               ? fmt.at("type").get<std::string>()
-                               : std::string();
-        if (type != "text") {
-            ApiError error;
-            error.message = "only response_format {type:text} is supported";
-            error.param   = "response_format";
-            error.code    = "response_format_not_supported";
-            throw ApiException(std::move(error));
-        }
+}
+
+void parse_response_format(const Json& body, GenerationRequest& out) {
+    if (!body.contains("response_format") || body.at("response_format").is_null()) { return; }
+    const Json& format = body.at("response_format");
+    if (!format.is_object()) {
+        bad_request("response_format must be an object or null", "response_format");
     }
+    if (!format.contains("type") || !format.at("type").is_string()) {
+        bad_request("response_format.type must be a string", "response_format.type");
+    }
+
+    const std::string type = format.at("type").get<std::string>();
+    if (type == "text") {
+        out.response_format.mode = ResponseFormatMode::Text;
+        return;
+    }
+    if (type == "json_object") {
+        out.response_format.mode = ResponseFormatMode::JsonObject;
+        return;
+    }
+    if (type != "json_schema") {
+        bad_request("response_format.type must be text, json_object, or json_schema",
+                    "response_format.type", "response_format_type_invalid");
+    }
+    if (!format.contains("json_schema") || !format.at("json_schema").is_object()) {
+        bad_request("response_format.json_schema must be an object",
+                    "response_format.json_schema");
+    }
+
+    const Json& definition = format.at("json_schema");
+    if (!definition.contains("name") || !definition.at("name").is_string() ||
+        definition.at("name").get_ref<const std::string&>().empty()) {
+        bad_request("response_format.json_schema.name must be a non-empty string",
+                    "response_format.json_schema.name");
+    }
+    if (!definition.contains("schema") || !definition.at("schema").is_object()) {
+        bad_request("response_format.json_schema.schema must be an object",
+                    "response_format.json_schema.schema");
+    }
+    if (definition.contains("strict") && !definition.at("strict").is_boolean()) {
+        bad_request("response_format.json_schema.strict must be a boolean",
+                    "response_format.json_schema.strict");
+    }
+
+    out.response_format.mode        = ResponseFormatMode::JsonSchema;
+    out.response_format.name        = definition.at("name").get<std::string>();
+    out.response_format.schema_json = definition.at("schema").dump();
+    out.response_format.strict      = definition.value("strict", false);
 }
 
 Json base_chunk(const std::string& id, const std::string& model, std::int64_t created) {
@@ -566,6 +602,7 @@ GenerationRequest parse_chat_completion_request(const Json& body, const RequestL
     parse_messages(body, out);
     parse_stop(body, out);
     parse_sampling(body, out);
+    parse_response_format(body, out);
 
     out.stream = get_bool(body, "stream", false);
     if (body.contains("stream_options") && body.at("stream_options").is_object()) {

--- a/src/serve/request.h
+++ b/src/serve/request.h
@@ -127,6 +127,25 @@ struct SamplingParams {
     int n = 1;
 };
 
+enum class ResponseFormatMode : std::uint8_t {
+    Text,
+    JsonObject,
+    JsonSchema,
+};
+
+// Wire-normalized structured-output contract. The schema stays serialized at
+// the serve boundary so the Engine API does not acquire a JSON-library type.
+struct ResponseFormat {
+    ResponseFormatMode mode = ResponseFormatMode::Text;
+    std::string name;
+    std::string schema_json;
+    bool strict = false;
+
+    [[nodiscard]] bool constrained() const noexcept {
+        return mode != ResponseFormatMode::Text;
+    }
+};
+
 // Protocol-level effort vocabulary. Each wire adapter accepts the values from
 // its external contract; translation then resolves them against the capabilities
 // advertised by the chat template embedded in the loaded artifact.
@@ -191,6 +210,7 @@ struct GenerationRequest {
     std::optional<bool> preserve_thinking;
     bool preserve_thinking_semantic_change = false;
     SamplingParams sampling;
+    ResponseFormat response_format;
 
     [[nodiscard]] bool uses_tools() const noexcept {
         return !tools.empty() && tool_choice.mode != ToolChoiceMode::None;

--- a/src/serve/translate.cpp
+++ b/src/serve/translate.cpp
@@ -238,6 +238,19 @@ ninfer::RequestOptions to_request_options(const GenerationRequest& request,
     options.execution.sampling             = resolve_sampling_overrides(request.sampling, server);
     options.output.raw                     = false;
     options.output.preserve_special_tokens = request.uses_tools() || request.has_tool_history();
+    switch (request.response_format.mode) {
+    case ResponseFormatMode::Text:
+        break;
+    case ResponseFormatMode::JsonObject:
+        options.structured_output.mode = ninfer::StructuredOutputMode::JsonObject;
+        break;
+    case ResponseFormatMode::JsonSchema:
+        options.structured_output.mode        = ninfer::StructuredOutputMode::JsonSchema;
+        options.structured_output.name        = request.response_format.name;
+        options.structured_output.schema_json = request.response_format.schema_json;
+        options.structured_output.strict      = request.response_format.strict;
+        break;
+    }
     options.stop.strings.reserve(request.stop_strings.size());
     for (const std::string& stop : request.stop_strings) {
         if (!stop.empty()) {

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/frontend.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/frontend.h
@@ -98,6 +98,8 @@ public:
     [[nodiscard]] runtime::OutputDecision preview_terminal(FinishReason reason);
     [[nodiscard]] PublishedOutput commit_preview() noexcept;
     [[nodiscard]] std::uint32_t reasoning_tokens() const noexcept;
+    [[nodiscard]] bool has_token_constraint() const noexcept;
+    [[nodiscard]] std::span<const std::uint32_t> next_token_bitmask();
 
 private:
     class Impl;
@@ -122,7 +124,8 @@ public:
     [[nodiscard]] PromptCapabilities prompt_capabilities() const noexcept;
     [[nodiscard]] OutputSession make_output_session(const PreparedPrompt& prompt,
                                                     const StopPolicy& caller_stop,
-                                                    const OutputOptions& output = {}) const;
+                                                    const OutputOptions& output = {},
+                                                    const StructuredOutputOptions& structured = {}) const;
     [[nodiscard]] const StopPolicy& default_stop_policy() const noexcept;
 
 private:

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/runtime.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/runtime.h
@@ -164,6 +164,7 @@ public:
     [[nodiscard]] runtime::BatchedGeneratedRound
     decode_batch(std::span<const std::uint32_t> lanes,
                  std::span<const runtime::RoundBudget> budgets);
+    void set_token_mask_lane(std::uint32_t lane, std::span<const std::uint32_t> mask);
     void resolve_prefill_lane(std::uint32_t lane, bool terminal);
     void resolve_pending_batch(std::span<const std::uint32_t> lanes,
                                std::span<const std::uint32_t> accepted_tokens,

--- a/src/targets/qwen3_6/impl/frontend/frontend.cpp
+++ b/src/targets/qwen3_6/impl/frontend/frontend.cpp
@@ -10,6 +10,9 @@
 #include "text/unicode.h"
 
 #include <nlohmann/json.hpp>
+#include <xgrammar/compiler.h>
+#include <xgrammar/matcher.h>
+#include <xgrammar/tokenizer_info.h>
 
 #include <algorithm>
 #include <array>
@@ -639,22 +642,44 @@ public:
             }
             defaults.token_ids.push_back(token);
         }
+        std::vector<std::int32_t> stop_tokens(defaults.token_ids.begin(), defaults.token_ids.end());
+        std::vector<std::string> decoded_vocab = tokenizer->decoded_vocabulary();
+        const int vocab_size                   = static_cast<int>(decoded_vocab.size());
+        grammar_compiler = std::make_shared<xgrammar::GrammarCompiler>(xgrammar::TokenizerInfo(
+            decoded_vocab, xgrammar::VocabType::RAW, vocab_size, std::move(stop_tokens)));
+        grammar_vocab_size = vocab_size;
     }
 
     fi::CompiledChatTemplate chat_template;
     std::shared_ptr<const fi::Tokenizer> tokenizer;
     fi::ProcessorOptions processor;
     StopPolicy defaults;
+    std::shared_ptr<xgrammar::GrammarCompiler> grammar_compiler;
+    int grammar_vocab_size = 0;
     bool vision_enabled = true;
 };
 
 class OutputSession::Impl {
 public:
     Impl(std::shared_ptr<const fi::Tokenizer> tokenizer_, StopPolicy policy_, OutputOptions output,
-         bool starts_in_reasoning)
+         const StructuredOutputOptions& structured, bool starts_in_reasoning,
+         const std::shared_ptr<xgrammar::GrammarCompiler>& compiler, int vocab_size)
         : tokenizer(std::move(tokenizer_)), policy(std::move(policy_)),
           preserve_special(output.raw || output.preserve_special_tokens) {
-        state.in_reasoning = starts_in_reasoning && !output.raw;
+        // A structured response starts at the grammar root and is published as content even when
+        // the model's normal mode would begin in a hidden reasoning channel.
+        state.in_reasoning = starts_in_reasoning && !output.raw && !structured.enabled();
+        if (structured.enabled()) {
+            xgrammar::CompiledGrammar grammar =
+                structured.mode == StructuredOutputMode::JsonObject
+                    ? compiler->CompileBuiltinJSONGrammar()
+                    : compiler->CompileJSONSchema(structured.schema_json, true, std::nullopt,
+                                                  std::nullopt, structured.strict);
+            std::vector<int> stops(policy.token_ids.begin(), policy.token_ids.end());
+            matcher.emplace(grammar, std::move(stops), false, -1);
+            mask.resize(static_cast<std::size_t>(xgrammar::GetBitmaskSize(vocab_size)));
+            grammar_vocab_size = vocab_size;
+        }
     }
 
     std::shared_ptr<const fi::Tokenizer> tokenizer;
@@ -664,6 +689,10 @@ public:
     DecoderState preview_state;
     PublishedOutput preview_output;
     bool preview_ready = false;
+    std::optional<xgrammar::GrammarMatcher> matcher;
+    std::optional<xgrammar::GrammarMatcher> preview_matcher;
+    std::vector<std::int32_t> mask;
+    int grammar_vocab_size = 0;
 };
 
 std::span<const std::int32_t> PreparedPromptData::position_axis(int axis) const {
@@ -744,8 +773,13 @@ runtime::OutputDecision OutputSession::preview(std::span<const TokenId> tokens,
 
     impl_->preview_state = impl_->state;
     impl_->preview_output.clear();
+    if (impl_->matcher) { impl_->preview_matcher = impl_->matcher->Fork(); }
+    std::uint32_t grammar_tokens = 0;
 
     const auto complete = [&](std::uint32_t count, FinishReason reason) {
+        if (impl_->preview_matcher && grammar_tokens > count) {
+            impl_->preview_matcher->Rollback(static_cast<int>(grammar_tokens - count));
+        }
         if (impl_->preview_output.size() == 1) {
             impl_->preview_output[0].tokens = count;
         } else if (impl_->preview_output.size() == 2) {
@@ -762,6 +796,12 @@ runtime::OutputDecision OutputSession::preview(std::span<const TokenId> tokens,
         if (!impl_->tokenizer->is_valid_token(token)) {
             throw std::out_of_range("generated token is outside the checkpoint vocabulary: " +
                                     std::to_string(token));
+        }
+        if (impl_->preview_matcher) {
+            if (!impl_->preview_matcher->AcceptToken(token)) {
+                throw std::logic_error("structured-output sampler produced a rejected token");
+            }
+            ++grammar_tokens;
         }
 
         if (impl_->preview_state.in_reasoning) { ++impl_->preview_state.reasoning_tokens; }
@@ -815,6 +855,7 @@ runtime::OutputDecision OutputSession::preview_terminal(FinishReason reason) {
         throw std::invalid_argument("invalid between-round terminal decoder reason");
     }
     impl_->preview_state = impl_->state;
+    if (impl_->matcher) { impl_->preview_matcher = impl_->matcher->Fork(); }
     impl_->preview_output.clear();
     terminalize(impl_->preview_state, impl_->policy, impl_->preview_output, 0);
     impl_->preview_ready = true;
@@ -825,10 +866,33 @@ PublishedOutput OutputSession::commit_preview() noexcept {
     if (impl_ == nullptr || !impl_->preview_ready) { std::terminate(); }
     using std::swap;
     swap(impl_->state, impl_->preview_state);
+    if (impl_->matcher) {
+        swap(impl_->matcher, impl_->preview_matcher);
+        impl_->preview_matcher.reset();
+    }
     PublishedOutput output = std::move(impl_->preview_output);
     impl_->preview_output.clear();
     impl_->preview_ready = false;
     return output;
+}
+
+bool OutputSession::has_token_constraint() const noexcept {
+    return impl_ != nullptr && impl_->matcher.has_value();
+}
+
+std::span<const std::uint32_t> OutputSession::next_token_bitmask() {
+    if (!has_token_constraint()) { return {}; }
+    std::int64_t shape = static_cast<std::int64_t>(impl_->mask.size());
+    DLTensor tensor{};
+    tensor.data        = impl_->mask.data();
+    tensor.device      = DLDevice{kDLCPU, 0};
+    tensor.ndim        = 1;
+    tensor.dtype       = xgrammar::GetBitmaskDLType();
+    tensor.shape       = &shape;
+    tensor.strides     = nullptr;
+    tensor.byte_offset = 0;
+    (void)impl_->matcher->FillNextTokenBitmask(&tensor);
+    return {reinterpret_cast<const std::uint32_t*>(impl_->mask.data()), impl_->mask.size()};
 }
 
 std::uint32_t OutputSession::reasoning_tokens() const noexcept {
@@ -976,12 +1040,14 @@ PreparedPrompt Frontend::prepare_tokens(std::vector<TokenId> token_ids,
 
 OutputSession Frontend::make_output_session(const PreparedPrompt& prompt,
                                             const StopPolicy& caller_stop,
-                                            const OutputOptions& output) const {
+                                            const OutputOptions& output,
+                                            const StructuredOutputOptions& structured) const {
     if (prompt.data_ == nullptr) { throw std::invalid_argument("prepared prompt is empty"); }
     StopPolicy policy = merge_stop_policy(*impl_->tokenizer, caller_stop);
     if (output.raw) { policy.publish_stop_token = true; }
     return OutputSession(std::make_unique<OutputSession::Impl>(
-        impl_->tokenizer, std::move(policy), output, prompt.data_->starts_in_reasoning));
+        impl_->tokenizer, std::move(policy), output, structured, prompt.data_->starts_in_reasoning,
+        impl_->grammar_compiler, impl_->grammar_vocab_size));
 }
 
 const StopPolicy& Frontend::default_stop_policy() const noexcept { return impl_->defaults; }

--- a/src/targets/qwen3_6/impl/frontend/frontend.cpp
+++ b/src/targets/qwen3_6/impl/frontend/frontend.cpp
@@ -799,7 +799,7 @@ runtime::OutputDecision OutputSession::preview(std::span<const TokenId> tokens,
         }
         if (impl_->preview_matcher) {
             if (!impl_->preview_matcher->AcceptToken(token)) {
-                throw std::logic_error("structured-output sampler produced a rejected token");
+                return complete(static_cast<std::uint32_t>(index), FinishReason::None);
             }
             ++grammar_tokens;
         }

--- a/src/targets/qwen3_6/impl/frontend/tokenizer.cpp
+++ b/src/targets/qwen3_6/impl/frontend/tokenizer.cpp
@@ -719,6 +719,17 @@ std::string Tokenizer::decode_token_bytes(int id, bool skip_special_tokens) cons
     return bytes;
 }
 
+std::vector<std::string> Tokenizer::decoded_vocabulary() const {
+    std::vector<std::string> result;
+    result.reserve(id_to_token_.size());
+    for (std::size_t id = 0; id < id_to_token_.size(); ++id) {
+        result.push_back(is_valid_token(static_cast<int>(id))
+                             ? decode_token_bytes(static_cast<int>(id), false)
+                             : std::string{});
+    }
+    return result;
+}
+
 bool Tokenizer::is_special_token(int id) const noexcept {
     return std::any_of(added_tokens_.begin(), added_tokens_.end(),
                        [id](const AddedToken& token) { return token.id == id && token.special; });

--- a/src/targets/qwen3_6/impl/frontend/tokenizer.h
+++ b/src/targets/qwen3_6/impl/frontend/tokenizer.h
@@ -49,6 +49,7 @@ public:
     [[nodiscard]] bool is_special_token(int id) const noexcept;
     [[nodiscard]] bool is_valid_token(int id) const noexcept;
     [[nodiscard]] bool has_exact_token_domain(std::size_t size) const noexcept;
+    [[nodiscard]] std::vector<std::string> decoded_vocabulary() const;
 
 private:
     std::vector<std::string> id_to_token_;

--- a/src/targets/qwen3_6/impl/runtime/api_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/api_impl.h
@@ -186,6 +186,12 @@ Program<Variant>::decode_batch(std::span<const std::uint32_t> lanes,
 }
 
 template <>
+void Program<Variant>::set_token_mask_lane(std::uint32_t lane,
+                                           std::span<const std::uint32_t> mask) {
+    impl_->set_token_mask_lane(lane, mask);
+}
+
+template <>
 void Program<Variant>::resolve_pending_batch(std::span<const std::uint32_t> lanes,
                                              std::span<const std::uint32_t> accepted_tokens,
                                              std::span<const std::uint8_t> terminal,

--- a/src/targets/qwen3_6/impl/runtime/layouts.h
+++ b/src/targets/qwen3_6/impl/runtime/layouts.h
@@ -41,6 +41,7 @@ struct PersistentLayout {
     TensorLayout prefill_hidden;
     TensorLayout token_counts;
     TensorLayout sampling_config;
+    TensorLayout token_masks;
     TensorLayout tail_hidden;
     TensorLayout turn_checkpoint_hidden;
     std::size_t bytes            = 0;

--- a/src/targets/qwen3_6/impl/runtime/layouts_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/layouts_impl.h
@@ -218,6 +218,10 @@ PersistentLayout persistent_layout(const SequencePlanImpl& plan) {
     out.sampling_config = add_tensor(
         builder, DType::I32, {config_words, static_cast<std::int32_t>(plan.max_concurrency)},
         "sampling config");
+    out.token_masks = add_tensor(
+        builder, DType::I32,
+        {(TextConfig::token_domain + 31) / 32, static_cast<std::int32_t>(plan.max_concurrency)},
+        "structured-output token masks");
     out.tail_hidden = add_tensor(
         builder, DType::BF16, {TextConfig::hidden, static_cast<std::int32_t>(plan.max_concurrency)},
         "tail hidden");

--- a/src/targets/qwen3_6/impl/runtime/program.h
+++ b/src/targets/qwen3_6/impl/runtime/program.h
@@ -56,6 +56,8 @@ struct RequestBasePlanImpl<NINFER_QWEN36_VARIANT> {
     std::size_t vision_transient_bytes = 0;
     std::optional<std::uint32_t> turn_rewrite_boundary;
     bool allow_prefix_reuse = false;
+    std::vector<std::uint32_t> token_mask;
+    bool disable_speculation = false;
 };
 
 template <>
@@ -74,6 +76,8 @@ struct RequestPlanImpl<NINFER_QWEN36_VARIANT> {
     std::uint32_t text_kv_page_entitlement    = 0;
     std::uint32_t backend_kv_page_entitlement = 0;
     std::filesystem::path disk_snapshot_path;
+    std::vector<std::uint32_t> token_mask;
+    bool disable_speculation = false;
 };
 
 } // namespace ninfer::targets::qwen3_6::detail
@@ -166,6 +170,7 @@ struct RequestControl {
     Lifecycle lifecycle = Lifecycle::Empty;
     PendingCandidate pending;
     ops::SamplingConfig sampling_host;
+    std::vector<std::uint32_t> initial_token_mask;
     GenerationTimings timings;
     SpeculativeStats speculative_stats;
 
@@ -214,6 +219,7 @@ public:
     [[nodiscard]] runtime::BatchedGeneratedRound
     decode_batch(std::span<const std::uint32_t> lanes,
                  std::span<const runtime::RoundBudget> budgets);
+    void set_token_mask_lane(std::uint32_t lane, std::span<const std::uint32_t> mask);
     void resolve_prefill_lane(std::uint32_t lane, bool terminal);
     void resolve_pending_batch(std::span<const std::uint32_t> lanes,
                                std::span<const std::uint32_t> accepted_tokens,
@@ -353,6 +359,7 @@ public:
     Tensor prefill_hidden;
     Tensor sampling_config;
     Tensor token_counts;
+    Tensor token_masks;
     Tensor tail_hidden_store;
     Tensor turn_checkpoint_hidden_store;
 

--- a/src/targets/qwen3_6/impl/runtime/program_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/program_impl.h
@@ -907,19 +907,17 @@ void ProgramImplCore::resolve_pending_batch(std::span<const std::uint32_t> lanes
         }
         const std::uint32_t committed = cancelled[row] ? 0U : accepted_tokens[row];
         if ((cancelled[row] && accepted_tokens[row] != 0) ||
-            (!cancelled[row] && (committed == 0 || committed > pending.produced ||
-                                 (!terminal[row] && committed != pending.produced)))) {
+            (!cancelled[row] && (committed == 0 || committed > pending.produced))) {
             throw std::logic_error("speculative pending row has an invalid committed prefix");
         }
         fold_rows[row] = ops::GdnReplayFoldRow{
             .linear_state_slot = LinearStateSlots::current_state_slot(lane, max_concurrency),
             .commit_columns    = static_cast<std::int32_t>(committed),
         };
-        const bool partial_terminal =
-            !cancelled[row] && terminal[row] && committed < pending.produced;
+        const bool partial_commit = !cancelled[row] && committed < pending.produced;
         hidden_selectors[row] =
-            static_cast<std::int32_t>(partial_terminal ? committed - 1U : pending.produced - 1U);
-        needs_hidden_correction = needs_hidden_correction || partial_terminal;
+            static_cast<std::int32_t>(partial_commit ? committed - 1U : pending.produced - 1U);
+        needs_hidden_correction = needs_hidden_correction || partial_commit;
     }
 
     const auto tail_started = Clock::now();
@@ -1017,7 +1015,7 @@ void ProgramImplCore::resolve_pending_batch(std::span<const std::uint32_t> lanes
 
             if (speculative_backend == SpeculativeBackend::Mtp) {
                 sequence.mtp_kv_valid = sequence.execution_frontier;
-                if (terminal[row]) {
+                if (terminal[row] || committed < pending.produced) {
                     sequence.mtp_draft_count = 0;
                 } else {
                     const std::int32_t next  = mtp_host_egress->next_extents[row];

--- a/src/targets/qwen3_6/impl/runtime/program_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/program_impl.h
@@ -270,6 +270,7 @@ ProgramImplCore::ProgramImplCore(const LoadedModelData& model_in, const Sequence
     prefill_hidden               = plan.persistent.prefill_hidden.bind(backing);
     token_counts                 = plan.persistent.token_counts.bind(backing);
     sampling_config              = plan.persistent.sampling_config.bind(backing);
+    token_masks                  = plan.persistent.token_masks.bind(backing);
     tail_hidden_store            = plan.persistent.tail_hidden.bind(backing);
     turn_checkpoint_hidden_store = plan.persistent.turn_checkpoint_hidden.bind(backing);
     for (std::uint32_t lane = 0; lane < max_concurrency; ++lane) {
@@ -469,7 +470,7 @@ runtime::PrefillStepResult ProgramImplCore::start_prefill_lane(std::uint32_t lan
     const auto started       = Clock::now();
     const std::uint32_t base = request_plan.reuse_base;
     const std::uint32_t initial_mtp_extent =
-        speculative_backend == SpeculativeBackend::Mtp
+        speculative_backend == SpeculativeBackend::Mtp && !request_plan.disable_speculation
             ? std::min({draft_window,
                         request_plan.summary.effective_output_tokens > 1
                             ? request_plan.summary.effective_output_tokens - 2
@@ -770,6 +771,11 @@ runtime::PrefillStepResult ProgramImplCore::start_prefill_lane(std::uint32_t lan
                                                                 : 0U;
         materialize_sequence_kv(sequence, prompt_tokens, backend_materialized);
         install_sampling(sequence, request, request_plan.sampling);
+        request.sampling_host.disable_speculation = request_plan.disable_speculation;
+        if (!request_plan.token_mask.empty()) {
+            request.initial_token_mask = std::move(request_plan.token_mask);
+            set_token_mask_lane(lane, request.initial_token_mask);
+        }
         if (request_plan.disk_snapshot_path.empty() || prompt.rope_delta != 0) {
             sequence.rope_delta = prompt.rope_delta;
         }
@@ -1632,6 +1638,23 @@ void ProgramImplCore::install_sampling(SequenceState& sequence, RequestControl& 
                                device.stream));
 }
 
+void ProgramImplCore::set_token_mask_lane(std::uint32_t lane,
+                                          std::span<const std::uint32_t> mask) {
+    if (lane >= max_concurrency) { throw std::out_of_range("token-mask lane is out of range"); }
+    const std::size_t expected = static_cast<std::size_t>((TextConfig::token_domain + 31) / 32);
+    if (mask.size() != expected) { throw std::invalid_argument("token mask has an invalid size"); }
+    Tensor device_mask = token_masks.slice(1, static_cast<std::int32_t>(lane), 1)
+                             .view({static_cast<std::int32_t>(expected)});
+    CUDA_CHECK(cudaMemcpyAsync(device_mask.data, mask.data(), device_mask.bytes(),
+                               cudaMemcpyHostToDevice, device.stream));
+    RequestControl& request       = requests[lane];
+    request.sampling_host.token_mask = static_cast<const std::uint32_t*>(device_mask.data);
+    Tensor config_lane = sampling_config.slice(1, static_cast<std::int32_t>(lane), 1);
+    CUDA_CHECK(cudaMemcpyAsync(config_lane.data, &request.sampling_host,
+                               sizeof(request.sampling_host), cudaMemcpyHostToDevice,
+                               device.stream));
+}
+
 void ProgramImplCore::copy_tail(SequenceState& sequence, const Tensor& source) {
     if (source.dtype != DType::BF16 || source.ne[0] != TextConfig::hidden || source.ne[1] != 1) {
         throw std::logic_error("target tail hidden has an invalid shape");
@@ -2101,7 +2124,8 @@ ProgramImplCore::decode_mtp_batch(std::span<const std::uint32_t> lanes,
         for (std::size_t row = 0; row < lanes.size(); ++row) {
             SequenceState& sequence           = sequences[lanes[row]];
             const RequestControl& request     = requests[lanes[row]];
-            if (sequence.mtp_draft_count == 0 && sequence.ledger.size() >= 3) {
+            if (!request.sampling_host.disable_speculation && sequence.mtp_draft_count == 0 &&
+                sequence.ledger.size() >= 3) {
                 const auto lookup =
                     find_prompt_lookup_draft(sequence.ledger, draft_window);
                 if (lookup.count > 0) {
@@ -2115,9 +2139,11 @@ ProgramImplCore::decode_mtp_batch(std::span<const std::uint32_t> lanes,
             const std::uint32_t max_by_budget = budgets[row].generated_tokens_remaining > 1
                                                     ? budgets[row].generated_tokens_remaining - 1
                                                     : 0;
-            const std::uint32_t extent =
-                std::min({sequence.mtp_draft_count, draft_window, max_by_budget,
-                          capacity - sequence.execution_frontier - 1});
+            const std::uint32_t extent = request.sampling_host.disable_speculation
+                                             ? 0U
+                                             : std::min({sequence.mtp_draft_count, draft_window,
+                                                         max_by_budget,
+                                                         capacity - sequence.execution_frontier - 1});
             mtp_host_ingress->anchors[row]        = sequence.ledger.back();
             mtp_host_ingress->base_frontiers[row] = checked_i32(frontier, "MTP batch frontier");
             mtp_host_ingress->remaining_budgets[row] =
@@ -2288,8 +2314,10 @@ ProgramImplCore::decode_dflash_batch(std::span<const std::uint32_t> lanes,
             const std::uint32_t max_by_budget = budgets[row].generated_tokens_remaining > 1
                                                     ? budgets[row].generated_tokens_remaining - 1U
                                                     : 0U;
-            const std::uint32_t extent =
-                std::min({draft_window, max_by_budget, capacity - frontier - 1U});
+            const std::uint32_t extent = request.sampling_host.disable_speculation
+                                             ? 0U
+                                             : std::min({draft_window, max_by_budget,
+                                                         capacity - frontier - 1U});
             dflash_host_ingress->anchors[row] = sequence.ledger.back();
             dflash_host_ingress->execution_frontiers[row] =
                 checked_i32(frontier, "DFlash batch frontier");

--- a/src/targets/qwen3_6/impl/runtime/request_plan_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/request_plan_impl.h
@@ -98,6 +98,8 @@ ProgramImplCore::plan_request_base(const PreparedPromptData& prompt,
     base->summary.transient_bytes        = 0;
     base->sampling                       = translate_sampling(options.sampling);
     base->allow_prefix_reuse             = options.allow_prefix_reuse;
+    base->token_mask                     = options.token_mask;
+    base->disable_speculation            = options.disable_speculation;
     const std::uint32_t reserved_context_tokens =
         base->summary.prompt_tokens + (base->summary.effective_output_tokens == 0
                                            ? 0U
@@ -178,6 +180,8 @@ RequestPlan ProgramImplCore::plan_request_for_lane(std::uint32_t lane,
     plan->sampling                    = base.sampling;
     plan->text_kv_page_entitlement    = base.text_kv_page_entitlement;
     plan->backend_kv_page_entitlement = base.backend_kv_page_entitlement;
+    plan->token_mask                  = base.token_mask;
+    plan->disable_speculation         = base.disable_speculation;
 
     if (base.allow_prefix_reuse && prompt.identity.reusable) {
         if (sequence.retained) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -132,7 +132,7 @@ ninfer_add_test(ninfer_qwen3_6_27b_load_plan_test
 target_include_directories(ninfer_qwen3_6_27b_load_plan_test PRIVATE
   ${PROJECT_SOURCE_DIR}/src/targets/qwen3_6/export
   ${PROJECT_SOURCE_DIR}/src/targets/qwen3_6_27b/export)
-target_link_libraries(ninfer_qwen3_6_27b_load_plan_test PRIVATE CUDA::cudart)
+target_link_libraries(ninfer_qwen3_6_27b_load_plan_test PRIVATE ${NINFER_CUDART_TARGET})
 set_tests_properties(ninfer_qwen3_6_27b_load_plan_test PROPERTIES SKIP_RETURN_CODE 77)
 ninfer_add_test(ninfer_qwen3_6_35b_a3b_real_test
   SOURCES targets/qwen3_6_35b_a3b/test_engine_real.cpp
@@ -149,7 +149,7 @@ ninfer_add_test(ninfer_qwen3_6_35b_a3b_dflash_load_plan_test
 target_include_directories(ninfer_qwen3_6_35b_a3b_dflash_load_plan_test PRIVATE
   ${PROJECT_SOURCE_DIR}/src/targets/qwen3_6/export
   ${PROJECT_SOURCE_DIR}/src/targets/qwen3_6_35b_a3b/export)
-target_link_libraries(ninfer_qwen3_6_35b_a3b_dflash_load_plan_test PRIVATE CUDA::cudart)
+target_link_libraries(ninfer_qwen3_6_35b_a3b_dflash_load_plan_test PRIVATE ${NINFER_CUDART_TARGET})
 set_tests_properties(ninfer_qwen3_6_35b_a3b_dflash_load_plan_test
   PROPERTIES SKIP_RETURN_CODE 77)
 
@@ -311,7 +311,7 @@ target_include_directories(ninfer_test_e8_codec PRIVATE
   ${PROJECT_SOURCE_DIR}/tools/test_kv
   ${PROJECT_SOURCE_DIR}/src/ops/kernel
   ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(ninfer_test_e8_codec PRIVATE CUDA::cudart)
+target_link_libraries(ninfer_test_e8_codec PRIVATE ${NINFER_CUDART_TARGET})
 set_target_properties(ninfer_test_e8_codec PROPERTIES CUDA_ARCHITECTURES "89")
 add_test(NAME ninfer_test_e8_codec COMMAND ninfer_test_e8_codec)
 set_tests_properties(ninfer_test_e8_codec PROPERTIES SKIP_RETURN_CODE 77)

--- a/tests/ops/test_sampling.cpp
+++ b/tests/ops/test_sampling.cpp
@@ -43,7 +43,8 @@ bool same_config(const ops::SamplingConfig& a, const ops::SamplingConfig& b) {
     return a.temperature == b.temperature && a.top_k == b.top_k && a.top_p == b.top_p &&
            a.min_p == b.min_p && a.presence_penalty == b.presence_penalty &&
            a.frequency_penalty == b.frequency_penalty && a.seed == b.seed &&
-           a.token_counts == b.token_counts;
+           a.token_counts == b.token_counts && a.token_mask == b.token_mask &&
+           a.disable_speculation == b.disable_speculation;
 }
 
 std::vector<std::uint16_t> bf16_bits(const std::vector<float>& values) {
@@ -137,12 +138,23 @@ Distribution distribution_oracle(const std::vector<float>& column, int token_dom
 RunResult run_batch(const std::vector<float>& logits, int physical_rows, int token_domain,
                     std::vector<ops::SamplingConfig> configs,
                     const std::vector<int>& logical_positions, int purpose,
-                    const std::vector<std::vector<int>>& initial_counts = {}) {
+                    const std::vector<std::vector<int>>& initial_counts = {},
+                    const std::vector<std::vector<std::uint32_t>>& token_masks = {}) {
     const int batch = static_cast<int>(configs.size());
     if (batch <= 0 || logical_positions.size() != configs.size() ||
         logits.size() != static_cast<std::size_t>(physical_rows) * configs.size() ||
-        (!initial_counts.empty() && initial_counts.size() != configs.size())) {
+        (!initial_counts.empty() && initial_counts.size() != configs.size()) ||
+        (!token_masks.empty() && token_masks.size() != configs.size())) {
         throw std::invalid_argument("invalid sample batch fixture");
+    }
+    std::vector<DeviceBuffer> device_masks;
+    device_masks.reserve(token_masks.size());
+    for (std::size_t row = 0; row < token_masks.size(); ++row) {
+        if (token_masks[row].size() != static_cast<std::size_t>((token_domain + 31) / 32)) {
+            throw std::invalid_argument("invalid sample token-mask fixture");
+        }
+        device_masks.push_back(to_device(token_masks[row]));
+        configs[row].token_mask = static_cast<const std::uint32_t*>(device_masks.back().p);
     }
     const std::vector<std::uint16_t> input_bits = bf16_bits(logits);
     DeviceBuffer device_logits                  = to_device(input_bits);
@@ -579,6 +591,21 @@ int workspace_route_boundary_contract() {
     return failures;
 }
 
+int token_mask_contract() {
+    constexpr int token_domain = 257;
+    std::vector<float> logits(static_cast<std::size_t>(token_domain), 0.0f);
+    logits[9]  = 8.0f;
+    logits[42] = 4.0f;
+    std::vector<std::uint32_t> mask(static_cast<std::size_t>((token_domain + 31) / 32), 0U);
+    mask[42U >> 5] |= 1U << (42U & 31U);
+    const RunResult result = run_batch(logits, token_domain, token_domain,
+                                       {ops::SamplingConfig{}}, {0},
+                                       ops::kSamplePurposeDecode, {}, {mask});
+    int failures = result.integrity_failures;
+    failures += verify_exact("sample token mask", result.tokens, {42});
+    return failures;
+}
+
 } // namespace
 
 int main() {
@@ -608,6 +635,7 @@ int main() {
     failures += real_shape_distribution_contract();
     failures += rng_key_contract();
     failures += workspace_route_boundary_contract();
+    failures += token_mask_contract();
 
     std::cout << (failures == 0 ? "OK" : "FAIL") << " sample public contract\n";
     return failures == 0 ? 0 : 1;

--- a/tests/ops/test_speculative_round.cpp
+++ b/tests/ops/test_speculative_round.cpp
@@ -410,6 +410,64 @@ int remap_case(int token_count) {
     return failures;
 }
 
+int grammar_masked_first_target_case(int token_domain) {
+    constexpr int k = 1;
+    const int physical_rows = token_domain;
+    std::vector<std::uint16_t> logits(static_cast<std::size_t>(physical_rows) * (k + 1),
+                                      f32_to_bf16(-20.0f));
+    logits[7]  = f32_to_bf16(30.0f); // Unconstrained target and draft.
+    logits[11] = f32_to_bf16(20.0f); // Best grammar-licensed correction.
+    logits[physical_rows + 13] = f32_to_bf16(20.0f);
+    std::vector<std::uint32_t> mask(static_cast<std::size_t>((token_domain + 31) / 32), 0U);
+    mask[11U >> 5] |= 1U << (11U & 31U);
+
+    DeviceBuffer d_targets = to_device<std::int32_t>({7, 13});
+    DeviceBuffer d_logits  = to_device(logits);
+    DeviceBuffer d_drafts  = to_device<std::int32_t>({7});
+    DeviceBuffer d_extent  = to_device<std::int32_t>({1});
+    DeviceBuffer d_lengths = to_device<std::int32_t>({100});
+    DeviceBuffer d_anchor  = to_device<std::int32_t>({-1});
+    DeviceBuffer d_tokens(static_cast<std::size_t>(k + 1) * sizeof(std::int32_t));
+    DeviceBuffer d_count(sizeof(std::int32_t));
+    DeviceBuffer d_accepted(sizeof(std::int32_t));
+    DeviceBuffer d_mask = to_device(mask);
+    ops::SamplingConfig config{};
+    config.temperature = 0.0f;
+    config.token_mask  = static_cast<const std::uint32_t*>(d_mask.p);
+    DeviceBuffer d_config = device_config(config);
+
+    Tensor targets(d_targets.p, DType::I32, {k + 1});
+    Tensor logits_tensor(d_logits.p, DType::BF16, {physical_rows, k + 1});
+    Tensor drafts(d_drafts.p, DType::I32, {k});
+    Tensor extent(d_extent.p, DType::I32, {1});
+    Tensor lengths(d_lengths.p, DType::I32, {1});
+    Tensor anchor(d_anchor.p, DType::I32, {1});
+    Tensor tokens(d_tokens.p, DType::I32, {k + 1});
+    Tensor count(d_count.p, DType::I32, {1});
+    Tensor accepted(d_accepted.p, DType::I32, {1});
+    const std::size_t workspace_bytes =
+        ops::speculative_accept_greedy_drafts_workspace_capacity_bytes(token_domain, k, k, 1, 1);
+    WorkspaceArena workspace(std::max<std::size_t>(256, workspace_bytes));
+    ops::speculative_accept_greedy_drafts(
+        targets, logits_tensor, drafts, extent, lengths, anchor, tokens, count, accepted,
+        token_domain, static_cast<const ops::SamplingConfig*>(d_config.p), workspace, nullptr);
+    cuda_synchronize();
+
+    const std::string label = "grammar-masked speculative first target V=" +
+                              std::to_string(token_domain);
+    int failures = verify_exact((label + " tokens").c_str(),
+                                from_device<std::int32_t>(d_tokens, k + 1), {11, 0});
+    failures += verify_exact((label + " count").c_str(),
+                             from_device<std::int32_t>(d_count, 1), {1});
+    failures += verify_exact((label + " accepted").c_str(),
+                             from_device<std::int32_t>(d_accepted, 1), {0});
+    failures += verify_exact((label + " anchor").c_str(),
+                             from_device<std::int32_t>(d_anchor, 1), {11});
+    failures += verify_exact((label + " length").c_str(),
+                             from_device<std::int32_t>(d_lengths, 1), {101});
+    return failures;
+}
+
 } // namespace
 
 int main() {
@@ -440,6 +498,8 @@ int main() {
     failures += greedy_accept_case(5, 5);
     failures += greedy_accept_case(15, 7, 257);
     failures += deterministic_sampling_case();
+    failures += grammar_masked_first_target_case(64);
+    failures += grammar_masked_first_target_case(2048);
     failures += batched_sampling_workspace_stride_case();
     failures += select_hidden_case(5120, 6, 0);
     failures += select_hidden_case(5120, 6, 5);

--- a/tests/ops/test_speculative_round.cpp
+++ b/tests/ops/test_speculative_round.cpp
@@ -468,6 +468,59 @@ int grammar_masked_first_target_case(int token_domain) {
     return failures;
 }
 
+int grammar_mask_only_first_sampling_column_case(int token_domain) {
+    constexpr int k = 1;
+    std::vector<std::uint16_t> logits(static_cast<std::size_t>(token_domain) * (k + 1),
+                                      f32_to_bf16(-20.0f));
+    logits[10]                = f32_to_bf16(20.0f);
+    logits[token_domain + 20] = f32_to_bf16(20.0f);
+    std::vector<std::uint32_t> mask(static_cast<std::size_t>((token_domain + 31) / 32), 0U);
+    mask[10U >> 5] |= 1U << (10U & 31U);
+
+    DeviceBuffer d_targets = to_device<std::int32_t>({10, 20});
+    DeviceBuffer d_logits  = to_device(logits);
+    DeviceBuffer d_drafts  = to_device<std::int32_t>({10});
+    DeviceBuffer d_extent  = to_device<std::int32_t>({1});
+    DeviceBuffer d_lengths = to_device<std::int32_t>({100});
+    DeviceBuffer d_anchor  = to_device<std::int32_t>({-1});
+    DeviceBuffer d_tokens(static_cast<std::size_t>(k + 1) * sizeof(std::int32_t));
+    DeviceBuffer d_count(sizeof(std::int32_t));
+    DeviceBuffer d_accepted(sizeof(std::int32_t));
+    DeviceBuffer d_mask = to_device(mask);
+    ops::SamplingConfig config{};
+    config.temperature = 1.0f;
+    config.top_k       = 1;
+    config.token_mask  = static_cast<const std::uint32_t*>(d_mask.p);
+    DeviceBuffer d_config = device_config(config);
+
+    Tensor targets(d_targets.p, DType::I32, {k + 1});
+    Tensor logits_tensor(d_logits.p, DType::BF16, {token_domain, k + 1});
+    Tensor drafts(d_drafts.p, DType::I32, {k});
+    Tensor extent(d_extent.p, DType::I32, {1});
+    Tensor lengths(d_lengths.p, DType::I32, {1});
+    Tensor anchor(d_anchor.p, DType::I32, {1});
+    Tensor tokens(d_tokens.p, DType::I32, {k + 1});
+    Tensor count(d_count.p, DType::I32, {1});
+    Tensor accepted(d_accepted.p, DType::I32, {1});
+    const std::size_t workspace_bytes =
+        ops::speculative_accept_greedy_drafts_workspace_capacity_bytes(token_domain, k, k, 1, 1);
+    WorkspaceArena workspace(std::max<std::size_t>(256, workspace_bytes));
+    ops::speculative_accept_greedy_drafts(
+        targets, logits_tensor, drafts, extent, lengths, anchor, tokens, count, accepted,
+        token_domain, static_cast<const ops::SamplingConfig*>(d_config.p), workspace, nullptr);
+    cuda_synchronize();
+
+    const std::string label = "grammar mask only first sampling column V=" +
+                              std::to_string(token_domain);
+    int failures = verify_exact((label + " tokens").c_str(),
+                                from_device<std::int32_t>(d_tokens, k + 1), {10, 20});
+    failures += verify_exact((label + " count").c_str(),
+                             from_device<std::int32_t>(d_count, 1), {2});
+    failures += verify_exact((label + " accepted").c_str(),
+                             from_device<std::int32_t>(d_accepted, 1), {1});
+    return failures;
+}
+
 } // namespace
 
 int main() {
@@ -500,6 +553,8 @@ int main() {
     failures += deterministic_sampling_case();
     failures += grammar_masked_first_target_case(64);
     failures += grammar_masked_first_target_case(2048);
+    failures += grammar_mask_only_first_sampling_column_case(64);
+    failures += grammar_mask_only_first_sampling_column_case(2048);
     failures += batched_sampling_workspace_stride_case();
     failures += select_hidden_case(5120, 6, 0);
     failures += select_hidden_case(5120, 6, 5);

--- a/tests/targets/qwen3_6/test_frontend.cpp
+++ b/tests/targets/qwen3_6/test_frontend.cpp
@@ -72,6 +72,7 @@ std::string read_file(const char* path) {
 
 std::string read_template_fixture(const char* path) {
     std::string source = read_file(path);
+    source.erase(std::remove(source.begin(), source.end(), '\r'), source.end());
     if (!source.empty() && source.back() == '\n') { source.pop_back(); }
     return source;
 }

--- a/tests/test_openai_schema.cpp
+++ b/tests/test_openai_schema.cpp
@@ -381,11 +381,52 @@ int test_reject_unsupported() {
         throws_api([&] { (void)parse_chat_completion_request(function_call, default_limits()); }),
         "deprecated function_call rejected");
 
-    Json rf               = base;
+    Json rf                = base;
     rf["response_format"] = Json{{"type", "json_object"}};
+    const GenerationRequest json_object_req =
+        parse_chat_completion_request(rf, default_limits());
+    failures += check(json_object_req.response_format.mode == ResponseFormatMode::JsonObject,
+                      "json_object response_format parsed");
     failures +=
-        check(throws_api([&] { (void)parse_chat_completion_request(rf, default_limits()); }),
-              "json response_format rejected");
+        check(to_request_options(json_object_req, default_server()).structured_output.mode ==
+                  ninfer::StructuredOutputMode::JsonObject,
+              "json_object response_format reaches Engine options");
+
+    Json rf_schema = base;
+    rf_schema["response_format"] =
+        Json{{"type", "json_schema"},
+             {"json_schema",
+              Json{{"name", "translation_batch"},
+                   {"strict", true},
+                   {"schema", Json{{"type", "object"},
+                                    {"properties", Json{{"translations", Json{{"type", "array"}}}}},
+                                    {"required", Json::array({"translations"})}}}}}};
+    const GenerationRequest json_schema_req =
+        parse_chat_completion_request(rf_schema, default_limits());
+    failures += check(json_schema_req.response_format.mode == ResponseFormatMode::JsonSchema,
+                      "json_schema response_format parsed");
+    failures += check(json_schema_req.response_format.name == "translation_batch",
+                      "json_schema name retained");
+    failures += check(json_schema_req.response_format.strict,
+                      "json_schema strict retained");
+    failures += check(Json::parse(json_schema_req.response_format.schema_json).at("type") ==
+                          "object",
+                      "json_schema body retained");
+    const ninfer::StructuredOutputOptions structured =
+        to_request_options(json_schema_req, default_server()).structured_output;
+    failures += check(structured.mode == ninfer::StructuredOutputMode::JsonSchema,
+                      "json_schema response_format reaches Engine options");
+    failures += check(structured.name == "translation_batch" && structured.strict,
+                      "json_schema Engine metadata retained");
+    failures += check(Json::parse(structured.schema_json).at("type") == "object",
+                      "json_schema Engine body retained");
+
+    Json invalid_rf = base;
+    invalid_rf["response_format"] = Json{{"type", "json_schema"},
+                                          {"json_schema", Json{{"name", "missing_schema"}}}};
+    failures += check(
+        throws_api([&] { (void)parse_chat_completion_request(invalid_rf, default_limits()); }),
+        "json_schema without schema rejected");
 
     Json rf_text               = base;
     rf_text["response_format"] = Json{{"type", "text"}};


### PR DESCRIPTION
## Summary

Add OpenAI-compatible `json_object` and `json_schema` structured output using XGrammar while preserving MTP speculative decoding.

Structured requests previously had no constrained decoding support. The initial implementation disabled speculation for correctness, reducing generation to one token per round. This branch makes the speculative verifier grammar-aware so structured output retains MTP acceleration.

## Upstream context

Mainline NInfer currently accepts only `response_format: {"type":"text"}` and rejects structured response formats in its schema tests.

Neroued/ninfer#87 previously proposed accepting `json_object` and `json_schema` through prompt injection. That PR was closed without merging and explicitly did not add an engine-level grammar facility. Prompt injection can encourage JSON, but cannot guarantee syntactic or schema-valid output.

This PR implements token-level constrained decoding instead: XGrammar licenses generated tokens, while the MTP verifier commits only a grammar-valid speculative prefix. It therefore addresses both guaranteed structure and preservation of speculative decoding performance.

Prior upstream attempt: https://github.com/Neroued/ninfer/pull/87

## Implementation

- Parse OpenAI `response_format` for `json_object` and strict `json_schema` requests.
- Compile and maintain an XGrammar matcher per output session.
- Apply the current grammar mask to the first licensed target token of every MTP round.
- Sequentially validate later speculative tokens and commit only the longest grammar-valid prefix.
- Correct ReplaySSM and continuation hidden state after partial nonterminal commits.
- Discard next-round drafts derived from a rejected suffix.
- Scope the position-zero grammar mask to position zero only; later stochastic MTP columns remain unconstrained until sequential grammar validation. This avoids distorting string contents with a stale mask.
- Cover both single-block and full-vocabulary multiblock sampling paths.

## Correctness

- Long deterministic run produced valid nested JSON containing all 100 required objects.
- Stochastic visual-context run at temperature 0.7 produced 50 scenes and 100 prose string fields with zero leading-colon artifacts.
- Added CUDA regressions proving:
  - an invalid first draft is replaced by the best grammar-licensed target;
  - the position-zero mask is not reused on later stochastic columns;
  - both small- and full-vocabulary paths behave correctly.

## Performance

Measured with Qwen3.8-27B on an RTX 4090:

| Workload | Throughput |
|---|---:|
| Structured output with speculation disabled | 33.5 tok/s |
| Structured output with MTP, deterministic nested schema | 113.6 tok/s |
| Structured output with MTP, temperature 0.7 visual schema | 99.7 tok/s |
| Ordinary unconstrained MTP baseline | 169.7 tok/s |

The deterministic structured workload improved by approximately 3.4x over the non-speculative structured path. The two structured figures use different prompts and sampling settings and should not be interpreted as an A/B regression.

## Validation

- Full build succeeds on Windows 11 with CUDA 13.x and MSVC on an RTX 4090.
- All 84 registered CTests passed with zero failures.
- Five real-model tests were skipped because their optional external fixtures were not installed.
- The OpenAI-compatible endpoint was tested end-to-end after deployment.
